### PR TITLE
chore: clean E2E lint baseline debt

### DIFF
--- a/e2e/debug-toolbar.spec.ts
+++ b/e2e/debug-toolbar.spec.ts
@@ -11,6 +11,12 @@ type FarmStorage = {
   collection: Array<{ varietyId: string }>;
 };
 
+type DebugToolbarWindow = Window & typeof globalThis & {
+  __e2eNavigationType?: string;
+  __e2eStorageLengthAtInit?: number;
+  __e2eStorageKeysAtInit?: string[];
+};
+
 async function dismissGuideIfPresent(page: import('@playwright/test').Page) {
   const getStarted = page.locator('button', { hasText: 'Get Started' });
   if (await getStarted.isVisible({ timeout: 2000 }).catch(() => false)) {
@@ -121,9 +127,10 @@ test.describe('Debug toolbar E2E', () => {
 
   test('reset all data clears localStorage and triggers a real page reload', async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).__e2eNavigationType = performance.getEntriesByType('navigation')[0]?.type ?? 'unknown';
-      (window as any).__e2eStorageLengthAtInit = localStorage.length;
-      (window as any).__e2eStorageKeysAtInit = Object.keys(localStorage);
+      const debugWindow = window as DebugToolbarWindow;
+      debugWindow.__e2eNavigationType = performance.getEntriesByType('navigation')[0]?.type ?? 'unknown';
+      debugWindow.__e2eStorageLengthAtInit = localStorage.length;
+      debugWindow.__e2eStorageKeysAtInit = Object.keys(localStorage);
     });
 
     await activateDebugMode(page);
@@ -137,14 +144,26 @@ test.describe('Debug toolbar E2E', () => {
     await expect.poll(async () => page.evaluate(() => localStorage.length)).toBeGreaterThan(0);
 
     await Promise.all([
-      page.waitForFunction(() => (window as any).__e2eNavigationType === 'reload'),
+      page.waitForFunction(() => {
+        const debugWindow = window as DebugToolbarWindow;
+        return debugWindow.__e2eNavigationType === 'reload';
+      }),
       page.getByRole('button', { name: '🔄 重置所有数据' }).click(),
     ]);
 
     await page.waitForLoadState('domcontentloaded');
 
-    await expect.poll(async () => page.evaluate(() => (window as any).__e2eNavigationType)).toBe('reload');
-    await expect.poll(async () => page.evaluate(() => (window as any).__e2eStorageLengthAtInit)).toBe(0);
-    await expect.poll(async () => page.evaluate(() => (window as any).__e2eStorageKeysAtInit.length)).toBe(0);
+    await expect.poll(async () => page.evaluate(() => {
+      const debugWindow = window as DebugToolbarWindow;
+      return debugWindow.__e2eNavigationType;
+    })).toBe('reload');
+    await expect.poll(async () => page.evaluate(() => {
+      const debugWindow = window as DebugToolbarWindow;
+      return debugWindow.__e2eStorageLengthAtInit;
+    })).toBe(0);
+    await expect.poll(async () => page.evaluate(() => {
+      const debugWindow = window as DebugToolbarWindow;
+      return debugWindow.__e2eStorageKeysAtInit?.length ?? -1;
+    })).toBe(0);
   });
 });

--- a/e2e/farm-layout-v023.spec.ts
+++ b/e2e/farm-layout-v023.spec.ts
@@ -148,7 +148,7 @@ test('AC7: farm grid uses transform-style: flat', async ({ page }) => {
 });
 
 // ─── AC8: 手机端一屏显示 ───
-test('AC8: mobile viewport (375px) shows all 7 plots without overflow', async ({ page, browserName }, testInfo) => {
+test('AC8: mobile viewport (375px) shows all 7 plots without overflow', async ({ page }, testInfo) => {
   if (testInfo.project.name !== 'mobile') {
     test.skip();
     return;

--- a/e2e/farm-mobile-square.spec.ts
+++ b/e2e/farm-mobile-square.spec.ts
@@ -150,10 +150,7 @@ test.describe('AC5: Theme switching', () => {
       const slots = grid.locator('> div');
       await expect(slots).toHaveCount(7);
 
-      // No error overlays or blank screens
-      const errorOverlay = page.locator('[class*="error"]');
-      const errorCount = await errorOverlay.count();
-      // Some elements may have "error" in class for styling, just ensure grid is visible
+      // Some elements may have "error" in class for styling, so only assert the grid stays visible.
       expect(await grid.isVisible()).toBe(true);
     });
   }

--- a/e2e/gene-lab.spec.ts
+++ b/e2e/gene-lab.spec.ts
@@ -56,20 +56,6 @@ async function goToFarm(page: import('@playwright/test').Page) {
   await expect(page.locator('.farm-grid-perspective')).toBeVisible();
 }
 
-async function activateDebugToolbar(page: import('@playwright/test').Page) {
-  const settingsButton = page.getByRole('button', { name: /settings|设置/i });
-  await settingsButton.click();
-  const settingsPanel = page.locator('.settings-scrollbar').first();
-  await expect(settingsPanel).toBeVisible();
-  const versionBadge = settingsPanel.locator('span').filter({ hasText: /^v\d+\.\d+\.\d+$/ });
-  await expect(versionBadge).toBeVisible();
-  for (let i = 0; i < 7; i += 1) {
-    await versionBadge.click();
-  }
-  await expect(page.getByText('🧪 Debug Toolbar')).toBeVisible();
-  await settingsButton.click();
-}
-
 async function openDebugPanel(page: import('@playwright/test').Page) {
   const debugTitle = page.getByText('🧪 Debug Toolbar');
   const resetButton = page.getByRole('button', { name: '🔄 重置所有数据' });

--- a/e2e/market-buy.spec.ts
+++ b/e2e/market-buy.spec.ts
@@ -125,15 +125,6 @@ async function readShedItemCount(page: Page, itemId: ShopItemId): Promise<number
   }, itemId);
 }
 
-async function readFarmPlotCount(page: Page): Promise<number> {
-  return page.evaluate(() => {
-    const raw = localStorage.getItem('watermelon-farm');
-    if (!raw) return 0;
-    const parsed = JSON.parse(raw) as { plots?: unknown };
-    return Array.isArray(parsed.plots) ? parsed.plots.length : 0;
-  });
-}
-
 test.describe('Market Buy', () => {
   test('AC1: 14 种常驻商品在买 Tab 正确展示', async ({ page }) => {
     expect(SHOP_ITEMS).toHaveLength(14);

--- a/e2e/market-sell.spec.ts
+++ b/e2e/market-sell.spec.ts
@@ -85,11 +85,6 @@ async function bootWithSeed(page: Page, payload: DebugState) {
   await page.reload();
 }
 
-async function goToFarm(page: Page) {
-  await page.getByRole('button', { name: '🌱' }).click();
-  await expect(page.locator('.farm-grid-perspective')).toBeVisible();
-}
-
 async function goToMarket(page: Page) {
   await page.getByRole('button', { name: '🏪' }).click();
   await expect(page.getByRole('heading', { name: zh.marketTitle })).toBeVisible();

--- a/e2e/mutation.spec.ts
+++ b/e2e/mutation.spec.ts
@@ -167,36 +167,6 @@ async function waitForMutationRoll(page: Page, plotId: number) {
   }, plotId, { timeout: 15_000 });
 }
 
-async function markFarmInactiveForOfflineGrowth(page: Page, inactiveMs: number) {
-  await page.evaluate((offlineMs: number) => {
-    const raw = localStorage.getItem('watermelon-farm');
-    if (!raw) return;
-
-    const farm = JSON.parse(raw) as {
-      lastActiveDate?: string;
-      lastActivityTimestamp?: number;
-      plots?: Array<Record<string, unknown>>;
-    };
-    const now = Date.now();
-    const inactiveAt = now - offlineMs;
-    const yesterday = new Date(now - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-
-    farm.lastActiveDate = yesterday;
-    farm.lastActivityTimestamp = inactiveAt;
-    if (Array.isArray(farm.plots)) {
-      farm.plots = farm.plots.map((plot) => {
-        if (plot.state !== 'growing' && plot.state !== 'mature') return plot;
-        return {
-          ...plot,
-          lastActivityTimestamp: inactiveAt,
-          lastUpdateDate: yesterday,
-        };
-      });
-    }
-    localStorage.setItem('watermelon-farm', JSON.stringify(farm));
-  }, inactiveMs);
-}
-
 async function useMutationGunOnce(page: Page, expectedChance: number) {
   const mutationButton = page.locator('button').filter({ hasText: zh.mutationGunUse }).first();
   if (!(await mutationButton.isVisible().catch(() => false))) {


### PR DESCRIPTION
Fixes #26

## What changed
- replaced the 7 `any` casts in `e2e/debug-toolbar.spec.ts` with a narrow `DebugToolbarWindow` type for the reload/localStorage assertions
- removed 6 unused bindings/helpers across the other 6 E2E files without changing test intent or runtime code paths
- kept the diff scoped to the 7 Issue #26 files only

## Verify
- `npx eslint e2e/debug-toolbar.spec.ts e2e/farm-layout-v023.spec.ts e2e/farm-mobile-square.spec.ts e2e/gene-lab.spec.ts e2e/market-buy.spec.ts e2e/market-sell.spec.ts e2e/mutation.spec.ts`
- `npx eslint . -f json -o artifacts/issue26/20260316-000010Z/repo-lint.json` -> repo-wide lint messages: 54 (down from 67)
- `npm run build`

## Known issues
- the remaining 54 lint messages are outside this issue's scope and intentionally left untouched
- proof artifacts are local in `artifacts/issue26/20260316-000010Z/`
