### PR TITLE
fix(lint): Issue #34 视觉层与插件专项 lint 收尾

### DIFF
--- a/artifacts/issue34/20260316-135219Z/PROOF.md
+++ b/artifacts/issue34/20260316-135219Z/PROOF.md
@@ -1,0 +1,124 @@
+# Issue #34 Proof — 视觉层与插件专项 lint 收尾
+
+- **Branch:** `feature/issue34-visual-plugin-lint`
+- **Issue:** `#34`
+- **PR:** pending
+- **Date:** 2026-03-16 13:52 UTC
+
+## 1. Targeted Lint Proof
+
+```bash
+$ npx eslint src/components/farm/SkyLayer.tsx \
+  src/components/SlicingScene.tsx \
+  src/components/farm-v2/FarmPlotTileV2.tsx \
+  src/hooks/useWeeklyShop.ts \
+  src/hooks/useAuth.ts \
+  auth/src/routes/auth.ts \
+  src/components/FarmPixiPhase0Prototype.tsx
+
+(no output)
+```
+
+- Target 7 files are lint-clean.
+- In-scope 8 messages removed.
+
+## 2. Repo-wide Lint Delta Proof
+
+- **Before (`origin/main` baseline):** 8 problems
+- **After (this branch):** 0 problems
+- **Delta:** -8 ✅
+
+```bash
+$ npx eslint .
+
+(no output)
+```
+
+## 3. Build Proof
+
+```bash
+$ npm run build
+
+vite v7.3.1 building client environment for production...
+✓ 131 modules transformed.
+✓ built in 4.07s
+```
+
+- Build passes.
+- Remaining output is the pre-existing CSS optimizer warning / chunk-size warning, not ESLint or TypeScript failures.
+
+## 4. Diff Check Proof
+
+```bash
+$ git diff --check
+
+(no output)
+```
+
+- Patch formatting is clean.
+
+## 5. Changed Files
+
+```text
+auth/src/routes/auth.ts
+src/components/FarmPixiPhase0Prototype.tsx
+src/components/SlicingScene.tsx
+src/components/farm-v2/FarmPlotBoardV2.tsx
+src/components/farm-v2/FarmPlotTileV2.tsx
+src/components/farm/SkyLayer.tsx
+src/hooks/useAuth.ts
+src/hooks/useWeeklyShop.ts
+artifacts/issue34/20260316-135219Z/PROOF.md
+```
+
+Notes:
+- The 7 target files were edited as requested.
+- `src/components/farm-v2/FarmPlotBoardV2.tsx` is the only extra code file: it is the sole consumer of `mapPlotStateToTileState`, so moving the helper usage there was the smallest strongly-coupled change needed to satisfy `react-refresh/only-export-components` without creating a new shared file.
+- The artifact file is proof-only.
+
+## 6. Fix Strategy Proof
+
+### `react-hooks/purity` x3
+
+- `src/components/farm/SkyLayer.tsx`
+  - Replaced render-time `Math.random()` cloud placement with deterministic per-count cloud layouts.
+- `src/hooks/useWeeklyShop.ts`
+  - Replaced render-time `createWeeklyShop(Date.now())` with a module-scope initial snapshot used only as the `useLocalStorage` fallback value.
+
+### `react-hooks/static-components` x1
+
+- `src/components/SlicingScene.tsx`
+  - Hoisted the watermelon SVG renderer to a file-level component and passed `isGold` as an explicit prop.
+
+### `react-refresh/only-export-components` x1
+
+- `src/components/farm-v2/FarmPlotTileV2.tsx`
+  - Stopped exporting the non-component helper from the component file.
+- `src/components/farm-v2/FarmPlotBoardV2.tsx`
+  - Inlined the strongly-coupled plot-state mapping helper at the single call site.
+
+### `react-hooks/immutability` x1
+
+- `src/hooks/useAuth.ts`
+  - Reworked token-refresh recursion to use an inner named helper (`scheduleTokenRefresh`) instead of self-referencing the `useCallback` variable during initialization.
+
+### `@typescript-eslint/no-unused-vars` x1
+
+- `auth/src/routes/auth.ts`
+  - Removed the unused `verifyAccessToken` import.
+
+### `react-hooks/exhaustive-deps` x1
+
+- `src/components/FarmPixiPhase0Prototype.tsx`
+  - Captured the mount element once inside the effect and reused that stable variable in async boot logic and cleanup instead of reading `mountRef.current` during cleanup.
+
+## 7. Regression Notes
+
+- No rules were relaxed, no ignores were added, and no lint comments were used to suppress debt.
+- No intended product behavior, visuals, or interaction goals were changed beyond making previously-random helper state deterministic.
+- I did not run extra runtime/browser regression flows beyond lint + build; risk is low because each change is localized to helper generation / export structure / cleanup safety / import cleanup.
+
+## 8. Known Issues
+
+- None in scope.
+- Repo-wide lint is now clean.

--- a/auth/src/routes/auth.ts
+++ b/auth/src/routes/auth.ts
@@ -3,7 +3,7 @@
  */
 import { Hono } from 'hono'
 import type { Env } from '../index'
-import { signAccessToken, verifyAccessToken, generateRefreshTokenId } from '../services/jwt'
+import { signAccessToken, generateRefreshTokenId } from '../services/jwt'
 import { sendVerificationEmail, generateCode } from '../services/email'
 import {
   googleAuthUrl, googleExchangeCode, googleUserInfo,

--- a/src/components/FarmPixiPhase0Prototype.tsx
+++ b/src/components/FarmPixiPhase0Prototype.tsx
@@ -279,6 +279,7 @@ export function FarmPixiPhase0Prototype() {
   useEffect(() => {
     let disposed = false;
     let resizeObserver: ResizeObserver | null = null;
+    const mountElement = mountRef.current;
 
     const boot = async () => {
       try {
@@ -289,7 +290,7 @@ export function FarmPixiPhase0Prototype() {
 
         if (disposed) return;
 
-        const host = mountRef.current;
+        const host = mountElement;
         if (!host) return;
 
         const width = Math.max(320, host.clientWidth || 320);
@@ -413,8 +414,8 @@ export function FarmPixiPhase0Prototype() {
       appRef.current = null;
       nodesRef.current = [];
       requestRenderRef.current = null;
-      if (mountRef.current) {
-        mountRef.current.innerHTML = '';
+      if (mountElement) {
+        mountElement.innerHTML = '';
       }
     };
   }, []);

--- a/src/components/SlicingScene.tsx
+++ b/src/components/SlicingScene.tsx
@@ -44,6 +44,25 @@ const GOLD_JUICE_COLORS = ['#fbbf24', '#f59e0b', '#fde68a', '#d97706', '#fef3c7'
 const SEED_QUALITY_EMOJI = { normal: '🌱', epic: '💎', legendary: '🌟' } as const;
 const SEED_QUALITY_COLOR = { normal: '#a3a3a3', epic: '#a78bfa', legendary: '#fbbf24' } as const;
 
+function WholeMelonSvg({ size = 120, isGold }: { size?: number; isGold: boolean }) {
+  const baseColor = isGold ? '#fbbf24' : '#2d8a4e';
+  const stripeColor = isGold ? '#d97706' : '#1a5c32';
+  const highlight = isGold ? '#fde68a' : '#4ade80';
+
+  return (
+    <svg width={size} height={size} viewBox="0 0 120 120">
+      <circle cx="60" cy="60" r="56" fill={baseColor} />
+      <path d="M60 4 C62 40, 68 80, 60 116" stroke={stripeColor} strokeWidth="5" fill="none" opacity="0.7" />
+      <path d="M30 10 C38 40, 44 80, 30 110" stroke={stripeColor} strokeWidth="4" fill="none" opacity="0.5" />
+      <path d="M90 10 C82 40, 76 80, 90 110" stroke={stripeColor} strokeWidth="4" fill="none" opacity="0.5" />
+      <path d="M15 30 C28 50, 28 70, 15 90" stroke={stripeColor} strokeWidth="3" fill="none" opacity="0.35" />
+      <path d="M105 30 C92 50, 92 70, 105 90" stroke={stripeColor} strokeWidth="3" fill="none" opacity="0.35" />
+      <ellipse cx="42" cy="35" rx="18" ry="12" fill={highlight} opacity="0.25" transform="rotate(-20 42 35)" />
+      <path d="M58 6 C56 0, 62 -2, 64 4" stroke={isGold ? '#92400e' : '#166534'} strokeWidth="2.5" fill="none" />
+    </svg>
+  );
+}
+
 export function SlicingScene({ melonType, comboCount, canContinue, pity, onComplete, onContinue, onCancel }: SlicingSceneProps) {
   const theme = useTheme();
   const t = useI18n();
@@ -72,30 +91,8 @@ export function SlicingScene({ melonType, comboCount, canContinue, pity, onCompl
     return () => { document.body.style.overscrollBehavior = prev; };
   }, []);
 
-  const juiceColors = melonType === 'legendary' ? GOLD_JUICE_COLORS : JUICE_COLORS;
-
-  // SVG whole watermelon for ready phase
-  const WholeMelonSVG = ({ size = 120 }: { size?: number }) => {
-    const isGold = melonType === 'legendary';
-    const baseColor = isGold ? '#fbbf24' : '#2d8a4e';
-    const stripeColor = isGold ? '#d97706' : '#1a5c32';
-    const highlight = isGold ? '#fde68a' : '#4ade80';
-    return (
-      <svg width={size} height={size} viewBox="0 0 120 120">
-        <circle cx="60" cy="60" r="56" fill={baseColor} />
-        {/* Stripes */}
-        <path d="M60 4 C62 40, 68 80, 60 116" stroke={stripeColor} strokeWidth="5" fill="none" opacity="0.7" />
-        <path d="M30 10 C38 40, 44 80, 30 110" stroke={stripeColor} strokeWidth="4" fill="none" opacity="0.5" />
-        <path d="M90 10 C82 40, 76 80, 90 110" stroke={stripeColor} strokeWidth="4" fill="none" opacity="0.5" />
-        <path d="M15 30 C28 50, 28 70, 15 90" stroke={stripeColor} strokeWidth="3" fill="none" opacity="0.35" />
-        <path d="M105 30 C92 50, 92 70, 105 90" stroke={stripeColor} strokeWidth="3" fill="none" opacity="0.35" />
-        {/* Highlight */}
-        <ellipse cx="42" cy="35" rx="18" ry="12" fill={highlight} opacity="0.25" transform="rotate(-20 42 35)" />
-        {/* Stem */}
-        <path d="M58 6 C56 0, 62 -2, 64 4" stroke={isGold ? '#92400e' : '#166534'} strokeWidth="2.5" fill="none" />
-      </svg>
-    );
-  };
+  const isGoldMelon = melonType === 'legendary';
+  const juiceColors = isGoldMelon ? GOLD_JUICE_COLORS : JUICE_COLORS;
 
   // 生成汁水粒子
   const spawnParticles = useCallback((cx: number, cy: number, angle: number) => {
@@ -347,7 +344,7 @@ export function SlicingScene({ melonType, comboCount, canContinue, pity, onCompl
         opacity: phase === 'result' ? 0 : 1,
         transition: phase === 'slicing' ? 'transform 0.15s ease-out' : 'transform 0.6s ease-in, opacity 0.3s',
       }}>
-        {(phase === 'ready' || phase === 'slicing') && <WholeMelonSVG size={120} />}
+        {(phase === 'ready' || phase === 'slicing') && <WholeMelonSvg size={120} isGold={isGoldMelon} />}
         {(phase === 'split' || phase === 'drops') && (
           <div className="relative" style={{ fontSize: 100 }}>
             <span className="absolute" style={{

--- a/src/components/farm-v2/FarmPlotBoardV2.tsx
+++ b/src/components/farm-v2/FarmPlotBoardV2.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { Plot, Weather } from '../../types/farm';
-import { FarmPlotTileV2, mapPlotStateToTileState } from './FarmPlotTileV2';
+import { FarmPlotTileV2 } from './FarmPlotTileV2';
 
 interface FarmPlotBoardV2Props {
   plots: Plot[];
@@ -16,6 +16,13 @@ interface FarmPlotBoardV2Props {
 const GRID_SIDE = 3;
 const TOTAL_PLOTS = GRID_SIDE * GRID_SIDE;
 const MOTION_CLASS = 'farm-v2-motion';
+
+function mapPlotStateToTileState(plot: Plot | null) {
+  if (!plot) return 'locked' as const;
+  if (plot.state === 'mature') return 'mature' as const;
+  if (plot.state === 'growing') return 'growing' as const;
+  return 'empty' as const;
+}
 
 function FarmHudV2({
   compactMode,

--- a/src/components/farm-v2/FarmPlotTileV2.tsx
+++ b/src/components/farm-v2/FarmPlotTileV2.tsx
@@ -1,5 +1,4 @@
 import type { CSSProperties } from 'react';
-import type { Plot } from '../../types/farm';
 
 export type FarmPlotTileState = 'empty' | 'growing' | 'mature' | 'locked';
 
@@ -330,11 +329,4 @@ export function FarmPlotTileV2({ state, onClick }: FarmPlotTileV2Props) {
       {isLocked && <LockedOverlay />}
     </div>
   );
-}
-
-export function mapPlotStateToTileState(plot: Plot | null): FarmPlotTileState {
-  if (!plot) return 'locked';
-  if (plot.state === 'mature') return 'mature';
-  if (plot.state === 'growing') return 'growing';
-  return 'empty';
 }

--- a/src/components/farm/SkyLayer.tsx
+++ b/src/components/farm/SkyLayer.tsx
@@ -16,6 +16,34 @@ interface CelestialPosition {
   y: string;
 }
 
+const CLOUD_LAYOUTS: Record<number, CelestialPosition[]> = {
+  0: [],
+  1: [
+    { x: '68%', y: '14%' },
+  ],
+  4: [
+    { x: '18%', y: '12%' },
+    { x: '72%', y: '10%' },
+    { x: '38%', y: '22%' },
+    { x: '84%', y: '26%' },
+  ],
+  5: [
+    { x: '14%', y: '12%' },
+    { x: '66%', y: '9%' },
+    { x: '34%', y: '20%' },
+    { x: '82%', y: '24%' },
+    { x: '54%', y: '30%' },
+  ],
+  6: [
+    { x: '12%', y: '10%' },
+    { x: '46%', y: '8%' },
+    { x: '78%', y: '12%' },
+    { x: '28%', y: '22%' },
+    { x: '64%', y: '24%' },
+    { x: '86%', y: '30%' },
+  ],
+};
+
 function getCloudCount(weather: Weather | null): number {
   if (weather === null) return 0;
   if (weather === 'sunny') return 1;
@@ -41,10 +69,7 @@ export function SkyLayer({ weather, currentTime }: SkyLayerProps) {
   const position = isNight ? { x: '75%', y: '15%' } : getSunPosition(hour);
   const cloudCount = getCloudCount(weather);
   const cloudPositions = useMemo<CelestialPosition[]>(
-    () => Array.from({ length: cloudCount }, () => ({
-      x: `${10 + Math.random() * 80}%`,
-      y: `${5 + Math.random() * 30}%`,
-    })),
+    () => CLOUD_LAYOUTS[cloudCount] ?? [],
     [cloudCount],
   );
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -35,34 +35,37 @@ export function useAuth() {
   }, [])
 
   const scheduleRefresh = useCallback((token: string) => {
-    // Parse JWT to get exp
-    try {
-      const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')))
-      const expiresIn = payload.exp * 1000 - Date.now()
-      // Refresh 1 minute before expiry
-      const refreshIn = Math.max(expiresIn - 60_000, 10_000)
-      if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current)
-      refreshTimerRef.current = setTimeout(async () => {
-        try {
-          const res = await fetch(`${AUTH_BASE}/auth/refresh`, {
-            method: 'POST',
-            credentials: 'include',
-          })
-          if (res.ok) {
-            const data = await res.json() as { accessToken: string }
-            localStorage.setItem(TOKEN_KEY, data.accessToken)
-            scheduleRefresh(data.accessToken)
-          } else {
+    function scheduleTokenRefresh(nextToken: string) {
+      try {
+        const payload = JSON.parse(atob(nextToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')))
+        const expiresIn = payload.exp * 1000 - Date.now()
+        // Refresh 1 minute before expiry
+        const refreshIn = Math.max(expiresIn - 60_000, 10_000)
+        if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current)
+        refreshTimerRef.current = setTimeout(async () => {
+          try {
+            const res = await fetch(`${AUTH_BASE}/auth/refresh`, {
+              method: 'POST',
+              credentials: 'include',
+            })
+            if (res.ok) {
+              const data = await res.json() as { accessToken: string }
+              localStorage.setItem(TOKEN_KEY, data.accessToken)
+              scheduleTokenRefresh(data.accessToken)
+            } else {
+              clearAuth()
+            }
+          } catch {
             clearAuth()
           }
-        } catch {
-          clearAuth()
-        }
-      }, refreshIn)
-    } catch {
-      // Invalid token format
-      clearAuth()
+        }, refreshIn)
+      } catch {
+        // Invalid token format
+        clearAuth()
+      }
     }
+
+    scheduleTokenRefresh(token)
   }, [clearAuth])
 
   const fetchMe = useCallback(async (token: string): Promise<User | null> => {

--- a/src/hooks/useWeeklyShop.ts
+++ b/src/hooks/useWeeklyShop.ts
@@ -23,6 +23,7 @@ import {
 
 const WEEKLY_SHOP_KEY = 'watermelon-weekly-shop';
 const AUTO_REFRESH_CHECK_INTERVAL_MS = 60 * 1000;
+const INITIAL_WEEKLY_SHOP = createWeeklyShop(Date.now());
 
 interface UseWeeklyShopOptions {
   spendCoins: (amount: number) => boolean;
@@ -149,7 +150,7 @@ export function useWeeklyShop(options: UseWeeklyShopOptions) {
   const { spendCoins, onGrantItem } = options;
   const [weeklyShop, setWeeklyShop] = useLocalStorage<WeeklyShop>(
     WEEKLY_SHOP_KEY,
-    createWeeklyShop(Date.now()),
+    INITIAL_WEEKLY_SHOP,
     migrateWeeklyShop,
   );
 


### PR DESCRIPTION
## Summary

Resolves #34

清理视觉层、插件专项 leftover lint，完成 Issue #24 拆单方案的最后一张执行单：
- `react-hooks/purity` x3
- `react-hooks/static-components` x1
- `react-refresh/only-export-components` x1
- `react-hooks/immutability` x1
- `@typescript-eslint/no-unused-vars` x1
- `react-hooks/exhaustive-deps` x1

Repo-wide lint: 8 → 0 problems (-8) ✅

## Changed Files

- `src/components/farm/SkyLayer.tsx`
- `src/components/SlicingScene.tsx`
- `src/components/farm-v2/FarmPlotTileV2.tsx`
- `src/components/farm-v2/FarmPlotBoardV2.tsx` (strongly-coupled helper)
- `src/hooks/useWeeklyShop.ts`
- `src/hooks/useAuth.ts`
- `auth/src/routes/auth.ts`
- `src/components/FarmPixiPhase0Prototype.tsx`

## Fix Strategy

### purity (3)
- SkyLayer: 用固定 layout 替换 Math.random 云朵位置
- useWeeklyShop: 用 module-scope 初始快照替换 render-time Date.now()

### static-components (1)
- SlicingScene: 提升 WholeMelonSvg 到文件级组件

### only-export-components (1)
- FarmPlotTileV2: 停止导出非组件 helper
- FarmPlotBoardV2: 在唯一调用点内联 helper

### immutability (1)
- useAuth: 用内部命名 helper 重构 token refresh 递归

### no-unused-vars (1)
- auth routes: 移除未使用的 verifyAccessToken import

### exhaustive-deps (1)
- FarmPixiPhase0Prototype: 在 effect 内捕获 mount element

## Verification

- ✅ 定向 lint (7 files): 0 errors
- ✅ Repo-wide lint: 0 problems
- ✅ Build: successful
- ✅ Diff check: clean
- ✅ 无功能变更，无新增 lint 问题

## Artifacts

`artifacts/issue34/20260316-135219Z/PROOF.md`

## Commit

`c2e039d`