### PR TITLE
fix: show owned count in dex detail

### DIFF
--- a/src/components/CollectionPage.tsx
+++ b/src/components/CollectionPage.tsx
@@ -13,6 +13,7 @@ import {
   GALAXIES,
   GALAXY_VARIETIES,
   getCollectedVarietyHarvestCount,
+  getCollectedVarietyOwnedCount,
   HYBRID_GALAXY_PAIRS,
   HYBRID_VARIETIES,
   PRISMATIC_VARIETIES,
@@ -35,6 +36,39 @@ interface CollectionPageProps {
 
 type CollectionTab = 'pure' | 'hybrid' | 'prismatic' | 'dark-matter';
 
+function pickEarlierDate(currentDate: string, nextDate: string): string {
+  if (!currentDate) return nextDate;
+  if (!nextDate) return currentDate;
+  return currentDate <= nextDate ? currentDate : nextDate;
+}
+
+function buildDexCollectionMap(collection: CollectedVariety[]): Map<VarietyId, CollectedVariety> {
+  return collection.reduce((map, record) => {
+    const existing = map.get(record.varietyId);
+    const ownedCount = getCollectedVarietyOwnedCount(record);
+    const harvestCount = getCollectedVarietyHarvestCount(record);
+
+    if (!existing) {
+      map.set(record.varietyId, {
+        varietyId: record.varietyId,
+        firstObtainedDate: record.firstObtainedDate,
+        count: ownedCount,
+        harvestCount,
+      });
+      return map;
+    }
+
+    map.set(record.varietyId, {
+      varietyId: record.varietyId,
+      firstObtainedDate: pickEarlierDate(existing.firstObtainedDate, record.firstObtainedDate),
+      count: getCollectedVarietyOwnedCount(existing) + ownedCount,
+      harvestCount: getCollectedVarietyHarvestCount(existing) + harvestCount,
+    });
+
+    return map;
+  }, new Map<VarietyId, CollectedVariety>());
+}
+
 export function CollectionPage({ collection, milestoneRewards }: CollectionPageProps) {
   const theme = useTheme();
   const t = useI18n();
@@ -42,7 +76,7 @@ export function CollectionPage({ collection, milestoneRewards }: CollectionPageP
   const [selectedVarietyId, setSelectedVarietyId] = useState<VarietyId | null>(null);
 
   const collectionMap = useMemo(
-    () => new Map(collection.map(item => [item.varietyId, item] as const)),
+    () => buildDexCollectionMap(collection),
     [collection],
   );
 
@@ -905,8 +939,14 @@ function VarietyDetailModal({ varietyId, collected, collectionCount, totalCount,
               <p className="text-xs mb-1" style={{ color: theme.textFaint }}>
                 {t.varietyDetailFirstObtained}
               </p>
-              <p className="text-sm font-medium mb-2" style={{ color: theme.text }}>
+              <p className="text-sm font-medium mb-3" style={{ color: theme.text }}>
                 {collected?.firstObtainedDate ?? '-'}
+              </p>
+              <p className="text-xs mb-1" style={{ color: theme.textFaint }}>
+                {t.varietyDetailOwnedCountLabel}
+              </p>
+              <p className="text-sm font-medium mb-2" style={{ color: theme.text }}>
+                {collected ? getCollectedVarietyOwnedCount(collected) : 0}
               </p>
               <p className="text-xs" style={{ color: theme.textMuted }}>
                 {t.varietyDetailHarvestCount(collected ? getCollectedVarietyHarvestCount(collected) : 0)}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -785,6 +785,7 @@ export const de: Messages = {
   }[id] ?? ''),
   varietyDetailTitle: 'Sortendetails',
   varietyDetailFirstObtained: 'Erstmals erhalten',
+  varietyDetailOwnedCountLabel: 'Aktuell im Besitz (Einheiten)',
   varietyDetailHarvestCount: (count) => `Insgesamt geerntet: ${count}x`,
   collectionAcquireHintTitle: 'So erhältst du sie',
   collectionGuideCurrentStage: 'Aktuelle Phase',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -785,6 +785,7 @@ export const en: Messages = {
   }[id] ?? ''),
   varietyDetailTitle: 'Variety Details',
   varietyDetailFirstObtained: 'First Obtained',
+  varietyDetailOwnedCountLabel: 'Current Owned (entities)',
   varietyDetailHarvestCount: (count) => `Total Harvests: ${count}`,
   collectionAcquireHintTitle: 'How to obtain',
   collectionGuideCurrentStage: 'Current stage',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -785,6 +785,7 @@ export const es: Messages = {
   }[id] ?? ''),
   varietyDetailTitle: 'Detalles de la variedad',
   varietyDetailFirstObtained: 'Primera obtención',
+  varietyDetailOwnedCountLabel: 'Cantidad actual en posesión (entidades)',
   varietyDetailHarvestCount: (count) => `Cosechada ${count} veces`,
   collectionAcquireHintTitle: 'Cómo obtenerla',
   collectionGuideCurrentStage: 'Etapa actual',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -785,6 +785,7 @@ export const fr: Messages = {
   }[id] ?? ''),
   varietyDetailTitle: 'Détails de la variété',
   varietyDetailFirstObtained: 'Première obtention',
+  varietyDetailOwnedCountLabel: 'Quantité actuellement possédée (entités)',
   varietyDetailHarvestCount: (count) => `Récoltée ${count} fois`,
   collectionAcquireHintTitle: 'Comment l’obtenir',
   collectionGuideCurrentStage: 'Étape actuelle',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -785,6 +785,7 @@ export const ja: Messages = {
   }[id] ?? ''),
   varietyDetailTitle: '品種の詳細',
   varietyDetailFirstObtained: '初回獲得日',
+  varietyDetailOwnedCountLabel: '現在の所持数（実体）',
   varietyDetailHarvestCount: (count) => `累計収穫回数：${count}回`,
   collectionAcquireHintTitle: '入手条件',
   collectionGuideCurrentStage: '現在の段階',

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -785,6 +785,7 @@ export const ko: Messages = {
   }[id] ?? ''),
   varietyDetailTitle: '품종 상세',
   varietyDetailFirstObtained: '첫 획득일',
+  varietyDetailOwnedCountLabel: '현재 보유 수량(실체)',
   varietyDetailHarvestCount: (count) => `누적 수확 ${count}회`,
   collectionAcquireHintTitle: '획득 조건',
   collectionGuideCurrentStage: '현재 단계',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -110,6 +110,7 @@ export const ru: Messages = {
     'blackhole-melon': 'Миниатюрная чёрная дыра: бесконечная мякоть в крошечном объёме.',
     'cosmic-heart': 'Семя первозданного арбуза. Когда все осколки собраны, оно возвращается само.',
   }[id] ?? en.varietyStory(id)),
+  varietyDetailOwnedCountLabel: 'Сейчас в наличии (единиц)',
   collectionAcquireHintTitle: 'Условие получения',
   darkMatterGuideVoid: 'Слейте 5 разных призматических генов',
   darkMatterGuideBlackHole: 'Слейте 10 пар двойных элементных генов',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -790,6 +790,7 @@ export const zh: Messages = {
   }[id] ?? ''),
   varietyDetailTitle: '品种详情',
   varietyDetailFirstObtained: '首次获得日期',
+  varietyDetailOwnedCountLabel: '当前持有数量（实体）',
   varietyDetailHarvestCount: (count) => `累计收获 ${count} 次`,
   collectionAcquireHintTitle: '获取条件',
   collectionGuideCurrentStage: '当前阶段',

--- a/src/i18n/locales/zhTW.ts
+++ b/src/i18n/locales/zhTW.ts
@@ -790,6 +790,7 @@ export const zhTW: Messages = {
   }[id] ?? ''),
   varietyDetailTitle: '品種詳情',
   varietyDetailFirstObtained: '首次獲得日期',
+  varietyDetailOwnedCountLabel: '目前持有數量（實體）',
   varietyDetailHarvestCount: (count) => `累計收穫 ${count} 次`,
   collectionAcquireHintTitle: '取得條件',
   collectionGuideCurrentStage: '當前階段',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -443,6 +443,7 @@ export interface Messages {
   varietyStory: (id: string) => string;
   varietyDetailTitle: string;
   varietyDetailFirstObtained: string;
+  varietyDetailOwnedCountLabel: string;
   varietyDetailHarvestCount: (count: number) => string;
   collectionAcquireHintTitle: string;
   collectionGuideCurrentStage: string;

--- a/src/types/farm.ts
+++ b/src/types/farm.ts
@@ -656,8 +656,12 @@ export interface CollectedVariety {
   harvestCount?: number; // cumulative harvest count for dex detail/history
 }
 
+export function getCollectedVarietyOwnedCount(record: CollectedVariety): number {
+  return Number.isFinite(record.count) ? Math.max(0, Math.floor(record.count)) : 0;
+}
+
 export function getCollectedVarietyHarvestCount(record: CollectedVariety): number {
-  const ownedCount = Number.isFinite(record.count) ? Math.max(0, Math.floor(record.count)) : 0;
+  const ownedCount = getCollectedVarietyOwnedCount(record);
   const storedHarvestCount = Number.isFinite(record.harvestCount)
     ? Math.max(0, Math.floor(record.harvestCount as number))
     : 0;


### PR DESCRIPTION
## Summary
- add a dedicated "Current Owned (entities)" field to the dex detail modal
- aggregate collection detail by `varietyId` so the owned count matches real inventory across split normal/mutant entries
- keep cumulative harvest count on its existing historical path, independent from current inventory

## Validation
- `npm run build`
- `git diff --check`
- `npx eslint src/components/CollectionPage.tsx src/types/farm.ts src/i18n/types.ts src/i18n/locales/en.ts src/i18n/locales/zh.ts src/i18n/locales/zhTW.ts src/i18n/locales/ja.ts src/i18n/locales/ko.ts src/i18n/locales/fr.ts src/i18n/locales/de.ts src/i18n/locales/es.ts src/i18n/locales/ru.ts`
- `npm run lint` *(fails on existing repo issue in `android/app/build/intermediates/assets/debug/mergeDebugAssets/native-bridge.js`: `Definition for rule '@typescript-eslint/no-unused-vars' was not found`)*

## Proof
- local proof bundle: `artifacts/issue-45/PROOF.md`
- screenshots:
  - `artifacts/issue-45/01-first-harvest-detail.png`
  - `artifacts/issue-45/02-repeat-harvest-detail.png`
  - `artifacts/issue-45/03-sell-decrements-owned-count.png`
  - `artifacts/issue-45/04-reload-keeps-owned-count.png`
  - `artifacts/issue-45/05-existing-save-alignment.png`


