### PR TITLE
feat(collection): show galaxy and rarity in detail header

### DIFF
--- a/src/components/CollectionPage.tsx
+++ b/src/components/CollectionPage.tsx
@@ -909,6 +909,7 @@ function VarietyDetailModal({ varietyId, collected, geneFragmentInventoryCount, 
 }) {
   const variety = VARIETY_DEFS[varietyId];
   const color = RARITY_COLOR[variety.rarity];
+  const rarityStars = RARITY_STARS[variety.rarity];
   const isCollected = Boolean(collected);
   const isDarkMatter = DARK_MATTER_VARIETIES.includes(varietyId as typeof DARK_MATTER_VARIETIES[number]);
 
@@ -943,9 +944,25 @@ function VarietyDetailModal({ varietyId, collected, geneFragmentInventoryCount, 
             {isCollected || isDarkMatter ? t.varietyName(varietyId) : '???'}
           </p>
           <div className="flex gap-1 mt-1">
-            {Array.from({ length: RARITY_STARS[variety.rarity] }).map((_, i) => (
+            {Array.from({ length: rarityStars }).map((_, i) => (
               <span key={i} style={{ color, fontSize: 14 }}>⭐</span>
             ))}
+          </div>
+          <div className="mt-3 flex w-full flex-wrap items-center justify-center gap-2">
+            <div
+              className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-medium sm:text-xs"
+              style={{ backgroundColor: `${theme.accent}14`, color: theme.accent }}
+            >
+              <span aria-hidden="true">🌌</span>
+              <span>{t.galaxyName(variety.galaxy)}</span>
+            </div>
+            <div
+              className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-medium sm:text-xs"
+              style={{ backgroundColor: `${color}16`, color }}
+            >
+              <span aria-hidden="true">⭐</span>
+              <span>{t.varietyDetailRarityText(rarityStars)}</span>
+            </div>
           </div>
         </div>
         {isCollected ? (

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -788,6 +788,7 @@ export const de: Messages = {
   varietyDetailOwnedCountLabel: 'Aktuell im Besitz (Einheiten)',
   varietyDetailGeneFragmentInventoryLabel: 'Genfragment-Bestand',
   varietyDetailHarvestCount: (count) => `Insgesamt geerntet: ${count}x`,
+  varietyDetailRarityText: (stars) => `${stars}-Sterne-Seltenheit`,
   collectionAcquireHintTitle: 'So erhältst du sie',
   collectionGuideCurrentStage: 'Aktuelle Phase',
   collectionGuideNextMilestone: 'Nächster Meilenstein',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -788,6 +788,7 @@ export const en: Messages = {
   varietyDetailOwnedCountLabel: 'Current Owned (entities)',
   varietyDetailGeneFragmentInventoryLabel: 'Gene Fragment Inventory',
   varietyDetailHarvestCount: (count) => `Total Harvests: ${count}`,
+  varietyDetailRarityText: (stars) => `${stars}-Star Rarity`,
   collectionAcquireHintTitle: 'How to obtain',
   collectionGuideCurrentStage: 'Current stage',
   collectionGuideNextMilestone: 'Next milestone',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -788,6 +788,7 @@ export const es: Messages = {
   varietyDetailOwnedCountLabel: 'Cantidad actual en posesión (entidades)',
   varietyDetailGeneFragmentInventoryLabel: 'Inventario de fragmentos genéticos',
   varietyDetailHarvestCount: (count) => `Cosechada ${count} veces`,
+  varietyDetailRarityText: (stars) => `Rareza de ${stars} estrellas`,
   collectionAcquireHintTitle: 'Cómo obtenerla',
   collectionGuideCurrentStage: 'Etapa actual',
   collectionGuideNextMilestone: 'Siguiente hito',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -788,6 +788,7 @@ export const fr: Messages = {
   varietyDetailOwnedCountLabel: 'Quantité actuellement possédée (entités)',
   varietyDetailGeneFragmentInventoryLabel: 'Inventaire des fragments génétiques',
   varietyDetailHarvestCount: (count) => `Récoltée ${count} fois`,
+  varietyDetailRarityText: (stars) => `Rareté ${stars} étoiles`,
   collectionAcquireHintTitle: 'Comment l’obtenir',
   collectionGuideCurrentStage: 'Étape actuelle',
   collectionGuideNextMilestone: 'Prochain jalon',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -788,6 +788,7 @@ export const ja: Messages = {
   varietyDetailOwnedCountLabel: '現在の所持数（実体）',
   varietyDetailGeneFragmentInventoryLabel: '遺伝子断片の所持数',
   varietyDetailHarvestCount: (count) => `累計収穫回数：${count}回`,
+  varietyDetailRarityText: (stars) => `${stars}つ星レア度`,
   collectionAcquireHintTitle: '入手条件',
   collectionGuideCurrentStage: '現在の段階',
   collectionGuideNextMilestone: '次のマイルストーン',

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -788,6 +788,7 @@ export const ko: Messages = {
   varietyDetailOwnedCountLabel: '현재 보유 수량(실체)',
   varietyDetailGeneFragmentInventoryLabel: '유전자 조각 보유량',
   varietyDetailHarvestCount: (count) => `누적 수확 ${count}회`,
+  varietyDetailRarityText: (stars) => `${stars}성 희귀도`,
   collectionAcquireHintTitle: '획득 조건',
   collectionGuideCurrentStage: '현재 단계',
   collectionGuideNextMilestone: '다음 마일스톤',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -112,6 +112,7 @@ export const ru: Messages = {
   }[id] ?? en.varietyStory(id)),
   varietyDetailOwnedCountLabel: 'Сейчас в наличии (единиц)',
   varietyDetailGeneFragmentInventoryLabel: 'Запас генных фрагментов',
+  varietyDetailRarityText: (stars) => `Редкость: ${stars} звезды`,
   collectionAcquireHintTitle: 'Условие получения',
   darkMatterGuideVoid: 'Слейте 5 разных призматических генов',
   darkMatterGuideBlackHole: 'Слейте 10 пар двойных элементных генов',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -793,6 +793,7 @@ export const zh: Messages = {
   varietyDetailOwnedCountLabel: '当前持有数量（实体）',
   varietyDetailGeneFragmentInventoryLabel: '基因碎片库存',
   varietyDetailHarvestCount: (count) => `累计收获 ${count} 次`,
+  varietyDetailRarityText: (stars) => `${stars}星稀有度`,
   collectionAcquireHintTitle: '获取条件',
   collectionGuideCurrentStage: '当前阶段',
   collectionGuideNextMilestone: '下一里程碑',

--- a/src/i18n/locales/zhTW.ts
+++ b/src/i18n/locales/zhTW.ts
@@ -793,6 +793,7 @@ export const zhTW: Messages = {
   varietyDetailOwnedCountLabel: '目前持有數量（實體）',
   varietyDetailGeneFragmentInventoryLabel: '基因碎片庫存',
   varietyDetailHarvestCount: (count) => `累計收穫 ${count} 次`,
+  varietyDetailRarityText: (stars) => `${stars}星稀有度`,
   collectionAcquireHintTitle: '取得條件',
   collectionGuideCurrentStage: '當前階段',
   collectionGuideNextMilestone: '下一里程碑',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -446,6 +446,7 @@ export interface Messages {
   varietyDetailOwnedCountLabel: string;
   varietyDetailGeneFragmentInventoryLabel: string;
   varietyDetailHarvestCount: (count: number) => string;
+  varietyDetailRarityText: (stars: number) => string;
   collectionAcquireHintTitle: string;
   collectionGuideCurrentStage: string;
   collectionGuideNextMilestone: string;


### PR DESCRIPTION
## Summary
- show galaxy and rarity text chips in the Collection detail modal header
- keep the existing emoji, star visuals, story, and four stats fields intact
- add `varietyDetailRarityText` across the supported locales

Closes #49