### PR TITLE
feat: show base drop rate in dex detail

### DIFF
--- a/src/components/CollectionPage.tsx
+++ b/src/components/CollectionPage.tsx
@@ -914,6 +914,9 @@ function VarietyDetailModal({ varietyId, collected, geneFragmentInventoryCount, 
   const isDarkMatter = DARK_MATTER_VARIETIES.includes(varietyId as typeof DARK_MATTER_VARIETIES[number]);
   const showStandardSellPrice = variety.sellPrice > 0
     && (variety.breedType === 'pure' || variety.breedType === 'hybrid' || variety.breedType === 'prismatic');
+  const showBaseDropRateChip = variety.breedType === 'pure' || variety.breedType === 'hybrid';
+  const baseDropRate = VARIETY_DEFS[varietyId].dropRate;
+  const baseDropRateLabel = `${Math.round(baseDropRate * 100)}%`;
   const showDarkMatterSellState = variety.breedType === 'dark-matter';
   const isDarkMatterNotSellable = showDarkMatterSellState && variety.sellPrice <= 0;
   const showSellChip = showStandardSellPrice || showDarkMatterSellState;
@@ -974,6 +977,15 @@ function VarietyDetailModal({ varietyId, collected, geneFragmentInventoryCount, 
               <span aria-hidden="true">⭐</span>
               <span>{t.varietyDetailRarityText(rarityStars)}</span>
             </div>
+            {showBaseDropRateChip && (
+              <div
+                className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-medium sm:text-xs"
+                style={{ backgroundColor: 'rgba(16, 185, 129, 0.14)', color: '#10b981' }}
+              >
+                <span aria-hidden="true">🎯</span>
+                <span>{baseDropRateLabel}</span>
+              </div>
+            )}
             {showSellChip && (
               <div
                 className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-medium sm:text-xs"


### PR DESCRIPTION
## Summary
- show base drop rate in the dex detail modal for pure and hybrid varieties only
- read the value directly from `VARIETY_DEFS[varietyId].dropRate` and display it as `Math.round(dropRate * 100)%`
- keep prismatic and dark-matter behavior unchanged

## Validation
- npm run build
- git diff --check
- npx eslint src/components/CollectionPage.tsx
- npm run lint *(fails on pre-existing generated file: `android/app/build/intermediates/assets/debug/mergeDebugAssets/native-bridge.js`)*

## Proof
- pure example: `jade-stripe` shows `🎯 15%`
- hybrid example: `lava-field` shows `🎯 60%`
- mobile and desktop modal layouts stay within the viewport without horizontal overflow