### PR TITLE
feat: show prismatic acquire hint in dex detail

### DIFF
--- a/src/components/CollectionPage.tsx
+++ b/src/components/CollectionPage.tsx
@@ -932,6 +932,9 @@ function VarietyDetailModal({ varietyId, collected, geneFragmentInventoryCount, 
     : varietyId === 'blackhole-melon'
       ? t.darkMatterGuideBlackHole
       : t.darkMatterGuideCosmicHeart;
+  const prismaticAcquireHint = variety.breedType === 'prismatic'
+    ? t.collectionPrismaticAcquireHint
+    : null;
 
   return (
     <div
@@ -1002,6 +1005,16 @@ function VarietyDetailModal({ varietyId, collected, geneFragmentInventoryCount, 
             <p className="text-sm leading-relaxed mb-4" style={{ color: theme.textMuted }}>
               {t.varietyStory(varietyId)}
             </p>
+            {prismaticAcquireHint && (
+              <div className="rounded-xl border p-3 mb-4" style={{ borderColor: theme.border, backgroundColor: `${theme.inputBg}70` }}>
+                <p className="text-xs mb-1" style={{ color: theme.textFaint }}>
+                  {t.collectionAcquireHintTitle}
+                </p>
+                <p className="text-sm font-medium" style={{ color: theme.text }}>
+                  {prismaticAcquireHint}
+                </p>
+              </div>
+            )}
             <div className="rounded-xl border p-3 mb-4" style={{ borderColor: theme.border, backgroundColor: `${theme.inputBg}70` }}>
               <p className="text-xs mb-1" style={{ color: theme.textFaint }}>
                 {t.varietyDetailFirstObtained}
@@ -1026,7 +1039,7 @@ function VarietyDetailModal({ varietyId, collected, geneFragmentInventoryCount, 
               </p>
             </div>
           </>
-        ) : (
+        ) : isDarkMatter ? (
           <div className="rounded-xl border p-3 mb-4" style={{ borderColor: theme.border, backgroundColor: `${theme.inputBg}70` }}>
             <p className="text-xs mb-1" style={{ color: theme.textFaint }}>
               {t.collectionAcquireHintTitle}
@@ -1040,7 +1053,7 @@ function VarietyDetailModal({ varietyId, collected, geneFragmentInventoryCount, 
               </p>
             )}
           </div>
-        )}
+        ) : null}
         <button
           type="button"
           onClick={onClose}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -792,6 +792,7 @@ export const de: Messages = {
   varietyDetailSellPrice: (price) => `Verkaufspreis: ${price} 💰`,
   varietyDetailNotSellable: 'Nicht verkaufbar',
   collectionAcquireHintTitle: 'So erhältst du sie',
+  collectionPrismaticAcquireHint: 'Die Fünf-Element-Resonanz schaltet den prismatischen Pfad frei. Die Fünf-Element-Fusion erzeugt einen Prismasamen, und aus diesem Samen wächst diese Sorte.',
   collectionGuideCurrentStage: 'Aktuelle Phase',
   collectionGuideNextMilestone: 'Nächster Meilenstein',
   collectionGuideFiveElementTitle: 'Fortschritt der Fünf-Elemente-Resonanz',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -792,6 +792,7 @@ export const en: Messages = {
   varietyDetailSellPrice: (price) => `Sell Price: ${price} 💰`,
   varietyDetailNotSellable: 'Not sellable',
   collectionAcquireHintTitle: 'How to obtain',
+  collectionPrismaticAcquireHint: 'Five-Element Resonance unlocks the prismatic route. Five-Element Fusion creates a prismatic seed, and that seed grows this variety.',
   collectionGuideCurrentStage: 'Current stage',
   collectionGuideNextMilestone: 'Next milestone',
   collectionGuideFiveElementTitle: 'Five-Element Resonance',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -792,6 +792,7 @@ export const es: Messages = {
   varietyDetailSellPrice: (price) => `Precio de venta: ${price} 💰`,
   varietyDetailNotSellable: 'No se puede vender',
   collectionAcquireHintTitle: 'Cómo obtenerla',
+  collectionPrismaticAcquireHint: 'La Resonancia de Cinco Elementos desbloquea la vía prismática. La Fusión de Cinco Elementos crea una semilla prismática, y de esa semilla nace esta variedad.',
   collectionGuideCurrentStage: 'Etapa actual',
   collectionGuideNextMilestone: 'Siguiente hito',
   collectionGuideFiveElementTitle: 'Progreso de resonancia de cinco elementos',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -792,6 +792,7 @@ export const fr: Messages = {
   varietyDetailSellPrice: (price) => `Prix de vente : ${price} 💰`,
   varietyDetailNotSellable: 'Non vendable',
   collectionAcquireHintTitle: 'Comment l’obtenir',
+  collectionPrismaticAcquireHint: 'La Résonance des Cinq Éléments débloque la voie prismatique. La Fusion des Cinq Éléments crée une graine prismatique, et cette graine donne cette variété.',
   collectionGuideCurrentStage: 'Étape actuelle',
   collectionGuideNextMilestone: 'Prochain jalon',
   collectionGuideFiveElementTitle: 'Progression de la résonance des cinq éléments',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -792,6 +792,7 @@ export const ja: Messages = {
   varietyDetailSellPrice: (price) => `売却価格：${price} 💰`,
   varietyDetailNotSellable: '売却不可',
   collectionAcquireHintTitle: '入手条件',
+  collectionPrismaticAcquireHint: '五行共鳴で幻彩ルートが解放され、五行融合で幻彩シードが作られ、そのシードからこの品種が育ちます。',
   collectionGuideCurrentStage: '現在の段階',
   collectionGuideNextMilestone: '次のマイルストーン',
   collectionGuideFiveElementTitle: '五行共鳴の進捗',

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -792,6 +792,7 @@ export const ko: Messages = {
   varietyDetailSellPrice: (price) => `판매 가격: ${price} 💰`,
   varietyDetailNotSellable: '판매 불가',
   collectionAcquireHintTitle: '획득 조건',
+  collectionPrismaticAcquireHint: '오행 공명이 환채 루트를 해제하고, 오행 융합이 환채 씨앗을 만들며, 그 씨앗에서 이 품종이 자랍니다.',
   collectionGuideCurrentStage: '현재 단계',
   collectionGuideNextMilestone: '다음 마일스톤',
   collectionGuideFiveElementTitle: '오행 공명 진행도',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -116,6 +116,7 @@ export const ru: Messages = {
   varietyDetailSellPrice: (price) => `Цена продажи: ${price} 💰`,
   varietyDetailNotSellable: 'Продажа недоступна',
   collectionAcquireHintTitle: 'Условие получения',
+  collectionPrismaticAcquireHint: 'Резонанс Пяти Стихий открывает призматический путь. Слияние Пяти Стихий создаёт призматическое семя, и из этого семени вырастает этот сорт.',
   darkMatterGuideVoid: 'Слейте 5 разных призматических генов',
   darkMatterGuideBlackHole: 'Слейте 10 пар двойных элементных генов',
   darkMatterGuideCosmicHeart: 'Соберите все 78 сортов',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -797,6 +797,7 @@ export const zh: Messages = {
   varietyDetailSellPrice: (price) => `售价：${price} 💰`,
   varietyDetailNotSellable: '不可出售',
   collectionAcquireHintTitle: '获取条件',
+  collectionPrismaticAcquireHint: '五行共鸣会解锁幻彩路线；五行融合会生成幻彩种子，而这颗种子会长成该品种。',
   collectionGuideCurrentStage: '当前阶段',
   collectionGuideNextMilestone: '下一里程碑',
   collectionGuideFiveElementTitle: '五行共鸣进度',

--- a/src/i18n/locales/zhTW.ts
+++ b/src/i18n/locales/zhTW.ts
@@ -797,6 +797,7 @@ export const zhTW: Messages = {
   varietyDetailSellPrice: (price) => `售價：${price} 💰`,
   varietyDetailNotSellable: '不可出售',
   collectionAcquireHintTitle: '取得條件',
+  collectionPrismaticAcquireHint: '五行共鳴會解鎖幻彩路線；五行融合會生成幻彩種子，而這顆種子會長成該品種。',
   collectionGuideCurrentStage: '當前階段',
   collectionGuideNextMilestone: '下一里程碑',
   collectionGuideFiveElementTitle: '五行共鳴進度',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -450,6 +450,7 @@ export interface Messages {
   varietyDetailSellPrice: (price: number) => string;
   varietyDetailNotSellable: string;
   collectionAcquireHintTitle: string;
+  collectionPrismaticAcquireHint: string;
   collectionGuideCurrentStage: string;
   collectionGuideNextMilestone: string;
   collectionGuideFiveElementTitle: string;


### PR DESCRIPTION
## Summary
- show a concise acquire hint in prismatic dex detail modals only
- keep the hint semantically aligned with the existing Five-Element Resonance -> Five-Element Fusion -> Prismatic Seed -> Prismatic Variety chain
- leave pure, hybrid, and dark-matter detail behavior unchanged

## Validation
- npm run build
- git diff --check
- npx eslint src/components/CollectionPage.tsx src/i18n/types.ts src/i18n/locales/en.ts src/i18n/locales/zh.ts
- npm run lint *(fails on pre-existing generated file: `android/app/build/intermediates/assets/debug/mergeDebugAssets/native-bridge.js`)*

## Proof
- collected prismatic example: `prism-melon` shows the new acquire-hint card in the detail modal
- semantic chain preserved: resonance unlocks the route, fusion creates the prismatic seed, and that seed grows the variety
- desktop and mobile modal layouts stay clear without overflow
