### PR TITLE
feat: bag purchased market seed items

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,7 +115,7 @@ import type {
   VarietyId,
   Weather,
 } from './types/farm';
-import { SHOP_ITEMS, PLOT_PRICES } from './types/market';
+import { SHOP_ITEMS, PLOT_PRICES, SHOP_SEED_ITEM_TO_QUALITY } from './types/market';
 import type { ShopItemId, WeeklyItem } from './types/market';
 import type { DarkMatterFusion, DarkMatterFusionType, FusionResult } from './types/gene';
 
@@ -712,8 +712,15 @@ function App() {
     if (!itemDef) return;
     const spent = spendCoins(itemDef.price);
     if (!spent) return;
+
+    const seedQuality = SHOP_SEED_ITEM_TO_QUALITY[itemId as keyof typeof SHOP_SEED_ITEM_TO_QUALITY];
+    if (seedQuality) {
+      addSeeds(1, seedQuality);
+      return;
+    }
+
     addShedItem(itemId, 1);
-  }, [addShedItem, spendCoins]);
+  }, [addSeeds, addShedItem, spendCoins]);
 
   const handleBuyPlot = useCallback((plotIndex: number) => {
     const price = PLOT_PRICES[plotIndex];

--- a/src/hooks/useShedStorage.ts
+++ b/src/hooks/useShedStorage.ts
@@ -17,6 +17,7 @@ import type {
 } from '../types/slicing';
 import { DEFAULT_SHED_STORAGE, DEFAULT_PITY, DEFAULT_SEED_COUNTS } from '../types/slicing';
 import { DARK_MATTER_VARIETIES, HYBRID_GALAXY_PAIRS, PRISMATIC_VARIETIES } from '../types/farm';
+import { SHOP_SEED_ITEM_TO_QUALITY } from '../types/market';
 
 const SHED_KEY = 'watermelon-shed';
 const INJECTED_SEED_QUALITIES: SeedQuality[] = ['normal', 'epic', 'legendary'];
@@ -54,9 +55,16 @@ function migrateShed(raw: unknown): ShedStorage {
     const items = s.items as Record<string, unknown>;
     const nextItems = result.items as Record<string, number>;
     for (const [id, value] of Object.entries(items)) {
-      if (typeof value === 'number' && Number.isFinite(value)) {
-        nextItems[id] = value;
+      if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+
+      const normalizedCount = Math.max(0, Math.floor(value));
+      const migratedSeedQuality = SHOP_SEED_ITEM_TO_QUALITY[id as keyof typeof SHOP_SEED_ITEM_TO_QUALITY];
+      if (migratedSeedQuality) {
+        result.seeds[migratedSeedQuality] += normalizedCount;
+        continue;
       }
+
+      nextItems[id] = normalizedCount;
     }
   }
 

--- a/src/types/market.ts
+++ b/src/types/market.ts
@@ -1,4 +1,5 @@
 import type { Rarity, VarietyId } from './farm';
+import type { SeedQuality } from './slicing';
 
 export type ShopItemId =
   | 'star-dew' | 'trap-net' | 'lullaby' | 'crystal-ball' | 'guardian-barrier'
@@ -28,6 +29,11 @@ export const SHOP_ITEMS: ShopItemDef[] = [
   { id: 'premium-seed', emoji: '💎', price: 200, category: 'seed' },
   { id: 'nectar', emoji: '⭐', price: 300, category: 'special' },
 ];
+
+export const SHOP_SEED_ITEM_TO_QUALITY = {
+  'mystery-seed': 'normal',
+  'premium-seed': 'epic',
+} as const satisfies Partial<Record<ShopItemId, SeedQuality>>;
 
 export const PLOT_PRICES: Record<number, number> = {
   4: 200,


### PR DESCRIPTION
## Summary
- route market seed purchases into real plantable bag stock via `shed.seeds`
- map `mystery-seed -> normal` and `premium-seed -> epic` without introducing a new quality tier
- migrate legacy broken `shed.items['mystery-seed'|'premium-seed']` counts into `shed.seeds` and clear the old slots

## Validation
- npm run build
- git diff --check
- npx eslint src/App.tsx src/hooks/useShedStorage.ts src/types/market.ts
- npm run lint *(fails on pre-existing generated file: `android/app/build/intermediates/assets/debug/mergeDebugAssets/native-bridge.js`)*

## Proof
- buying `mystery-seed` raises `shed.seeds.normal` by 1 and does not store the SKU in `shed.items`
- buying `premium-seed` raises `shed.seeds.epic` by 1 and does not store the SKU in `shed.items`
- farm planting modal immediately shows the new normal / epic inventory
- planting one normal seed decrements `shed.seeds.normal` from 1 to 0 and persists after reload
- seeded legacy `shed.items['mystery-seed']=2` and `shed.items['premium-seed']=3` migrate into `shed.seeds.normal/epic`, while unrelated items remain intact
