### PR TITLE
feat: add star dew plot boost

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -239,6 +239,7 @@ function App() {
     markStolenRecordRecovered,
     revivePlot,
     upgradePlotRarity,
+    halvePlotRemainingMatureTime,
   } = useFarmStorage();
   const { geneInventory, setGeneInventory, addFragment, removeFragment, removeFragmentsByGalaxy } = useGeneStorage();
   const { balance, addCoins, spendCoins, setBalance } = useMelonCoin();
@@ -777,6 +778,23 @@ function App() {
     }
     enqueueRecoveryToast(t.itemMoonDewSuccess);
   }, [farm.plots, consumeShopItem, upgradePlotRarity, addShedItem, enqueueRecoveryToast, t]);
+
+  const handleUseStarDew = useCallback((plotId: number) => {
+    const plot = farm.plots.find((item) => item.id === plotId);
+    if (!plot || plot.state !== 'growing' || !plot.varietyId) return;
+
+    const consumed = consumeShopItem('star-dew');
+    if (!consumed) return;
+
+    const result = halvePlotRemainingMatureTime(plotId);
+    if (!result.success) {
+      addShedItem('star-dew', 1);
+      return;
+    }
+    if (result.mutationOutcome) {
+      enqueueMutationToasts([result.mutationOutcome]);
+    }
+  }, [farm.plots, consumeShopItem, halvePlotRemainingMatureTime, addShedItem, enqueueMutationToasts]);
 
   const handleUseNectar = useCallback((plotId: number) => {
     const plot = farm.plots.find((item) => item.id === plotId);
@@ -1888,6 +1906,7 @@ function App() {
             onClear={clearPlot}
             onUseMutationGun={handleUseMutationGun}
             onUseMoonDew={handleUseMoonDew}
+            onUseStarDew={handleUseStarDew}
             onUseNectar={handleUseNectar}
             onUseStarTracker={handleUseStarTracker}
             onUseGuardianBarrier={handleUseGuardianBarrier}

--- a/src/components/FarmPage.tsx
+++ b/src/components/FarmPage.tsx
@@ -69,6 +69,7 @@ interface FarmPageProps {
   onClear: (plotId: number) => void;
   onUseMutationGun: (plotId: number) => void;
   onUseMoonDew: (plotId: number) => void;
+  onUseStarDew: (plotId: number) => void;
   onUseNectar: (plotId: number) => void;
   onUseStarTracker: (plotId: number) => void;
   onUseGuardianBarrier: () => void;
@@ -124,6 +125,7 @@ export function FarmPage({
   onClear,
   onUseMutationGun,
   onUseMoonDew,
+  onUseStarDew,
   onUseNectar,
   onUseStarTracker,
   onUseGuardianBarrier,
@@ -255,11 +257,13 @@ export function FarmPage({
   );
   const mutationGunCount = (items as Record<string, number>)['mutation-gun'] ?? 0;
   const moonDewCount = (items as Record<string, number>)['moon-dew'] ?? 0;
+  const starDewCount = (items as Record<string, number>)['star-dew'] ?? 0;
   const nectarCount = (items as Record<string, number>)['nectar'] ?? 0;
   const starTrackerCount = (items as Record<string, number>)['star-tracker'] ?? 0;
   const guardianBarrierCount = (items as Record<string, number>)['guardian-barrier'] ?? 0;
   const trapNetCount = (items as Record<string, number>)['trap-net'] ?? 0;
   const barrierActiveToday = farm.guardianBarrierDate === todayKey;
+  const canUseActivePlotStarDew = Boolean(activeGrowingPlot?.varietyId) && starDewCount > 0;
 
   const latestStolenRecordByPlotId = useMemo(() => {
     const latestByPlot = new Map<number, StolenRecord>();
@@ -451,6 +455,7 @@ export function FarmPage({
               stolenRecordByPlotId={latestStolenRecordByPlotId}
               mutationGunCount={mutationGunCount}
               moonDewCount={moonDewCount}
+              starDewCount={starDewCount}
               nectarCount={nectarCount}
               starTrackerCount={starTrackerCount}
               trapNetCount={trapNetCount}
@@ -462,6 +467,7 @@ export function FarmPage({
               onClear={onClear}
               onUseMutationGun={onUseMutationGun}
               onUseMoonDew={onUseMoonDew}
+              onUseStarDew={onUseStarDew}
               onUseNectar={onUseNectar}
               onUseStarTracker={onUseStarTracker}
               onUseTrapNet={onUseTrapNet}
@@ -509,6 +515,17 @@ export function FarmPage({
           )}
           {activeGrowingSnapshot.needsFocusHint && (
             <div className="mt-1 text-[11px]" style={{ color: theme.textMuted }}>{t.farmFocusBoostHint}</div>
+          )}
+          {canUseActivePlotStarDew && activeGrowingPlot && (
+            <button
+              type="button"
+              onClick={() => onUseStarDew(activeGrowingPlot.id)}
+              data-testid="farm-v2-star-dew-action"
+              className="mt-2 w-full rounded-[var(--radius-sm)] px-3 py-2 text-[11px] font-semibold transition-all duration-200 ease-out hover:-translate-y-0.5"
+              style={{ color: '#000', background: 'linear-gradient(135deg, #fde68a 0%, #fbbf24 58%, #fb7185 100%)' }}
+            >
+              ✨ {t.itemName('star-dew')} · {starDewCount}
+            </button>
           )}
         </div>
       )}
@@ -675,6 +692,8 @@ export interface PlotCardProps {
   onUseMutationGun: () => void;
   moonDewCount: number;
   onUseMoonDew: () => void;
+  starDewCount: number;
+  onUseStarDew: () => void;
   nectarCount: number;
   onUseNectar: () => void;
   starTrackerCount: number;
@@ -683,7 +702,7 @@ export interface PlotCardProps {
   onUseTrapNet: () => void;
 }
 
-export function PlotCard({ plot, stolenRecord, nowTimestamp, theme, t, isTooltipOpen, onTooltipToggle, onPlantClick, onHarvestClick, onClearClick, mutationGunCount, onUseMutationGun, moonDewCount, onUseMoonDew, nectarCount, onUseNectar, starTrackerCount, onUseStarTracker, trapNetCount, onUseTrapNet }: PlotCardProps) {
+export function PlotCard({ plot, stolenRecord, nowTimestamp, theme, t, isTooltipOpen, onTooltipToggle, onPlantClick, onHarvestClick, onClearClick, mutationGunCount, onUseMutationGun, moonDewCount, onUseMoonDew, starDewCount, onUseStarDew, nectarCount, onUseNectar, starTrackerCount, onUseStarTracker, trapNetCount, onUseTrapNet }: PlotCardProps) {
   const variety = plot.varietyId ? VARIETY_DEFS[plot.varietyId] : null;
   const varietyLabel = plot.varietyId
     ? `${t.varietyName(plot.varietyId)}${plot.isMutant ? ` · ${t.mutationPositive}` : ''}`
@@ -702,6 +721,7 @@ export function PlotCard({ plot, stolenRecord, nowTimestamp, theme, t, isTooltip
     && mutationGunCount > 0
     && !isMutationResolved
     && plot.progress < 0.20;
+  const canUseStarDew = plot.state === 'growing' && Boolean(plot.varietyId) && starDewCount > 0;
   const canUseMoonDew = plot.state === 'mature' && moonDewCount > 0;
   const canUseNectar = plot.state === 'withered' && nectarCount > 0;
   const canUseStarTracker = (plot.state === 'growing' || plot.state === 'mature') && starTrackerCount > 0 && !plot.hasTracker;
@@ -1010,6 +1030,16 @@ export function PlotCard({ plot, stolenRecord, nowTimestamp, theme, t, isTooltip
                         {`🔦 ${t.mutationGunUse} · ${mutationGunCount}`}
                       </button>
                     </>
+                  )}
+                  {canUseStarDew && (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); onUseStarDew(); }}
+                      data-testid="farm-legacy-star-dew-action"
+                      className="w-full px-3 py-2 text-[11px] font-medium cursor-pointer transition-all duration-200 ease-out hover:-translate-y-0.5"
+                      style={{ color: '#000', background: 'linear-gradient(135deg, #fde68a 0%, #fbbf24 58%, #fb7185 100%)' }}
+                    >
+                      ✨ {t.itemName('star-dew')} · {starDewCount}
+                    </button>
                   )}
                   {canUseStarTracker && (
                     <button

--- a/src/components/farm/SimpleFarmGrid.tsx
+++ b/src/components/farm/SimpleFarmGrid.tsx
@@ -20,6 +20,7 @@ interface SimpleFarmGridProps {
   stolenRecordByPlotId?: Map<number, StolenRecord>;
   mutationGunCount: number;
   moonDewCount: number;
+  starDewCount: number;
   nectarCount: number;
   starTrackerCount: number;
   trapNetCount: number;
@@ -29,6 +30,7 @@ interface SimpleFarmGridProps {
   onClear: (plotId: number) => void;
   onUseMutationGun: (plotId: number) => void;
   onUseMoonDew: (plotId: number) => void;
+  onUseStarDew: (plotId: number) => void;
   onUseNectar: (plotId: number) => void;
   onUseStarTracker: (plotId: number) => void;
   onUseTrapNet: (plotId: number) => void;
@@ -213,6 +215,7 @@ export function SimpleFarmGrid({
   stolenRecordByPlotId,
   mutationGunCount,
   moonDewCount,
+  starDewCount,
   nectarCount,
   starTrackerCount,
   trapNetCount,
@@ -222,6 +225,7 @@ export function SimpleFarmGrid({
   onClear,
   onUseMutationGun,
   onUseMoonDew,
+  onUseStarDew,
   onUseNectar,
   onUseStarTracker,
   onUseTrapNet,
@@ -549,6 +553,8 @@ export function SimpleFarmGrid({
                         onUseMutationGun={() => onUseMutationGun(plot.id)}
                         moonDewCount={moonDewCount}
                         onUseMoonDew={() => onUseMoonDew(plot.id)}
+                        starDewCount={starDewCount}
+                        onUseStarDew={() => onUseStarDew(plot.id)}
                         nectarCount={nectarCount}
                         onUseNectar={() => onUseNectar(plot.id)}
                         starTrackerCount={starTrackerCount}

--- a/src/hooks/useFarmStorage.ts
+++ b/src/hooks/useFarmStorage.ts
@@ -28,7 +28,7 @@ import {
 } from '../types/farm';
 import { DEFAULT_SEED_COUNTS } from '../types/slicing';
 import { getPlotCount } from '../farm/galaxy';
-import { rollVariety } from '../farm/growth';
+import { rollVariety, updatePlotGrowth, type MutationOutcome } from '../farm/growth';
 
 const FARM_KEY = 'watermelon-farm';
 const MAX_PLOT_COUNT = 9;
@@ -870,6 +870,38 @@ export function useFarmStorage() {
     return true;
   }, [farm.plots, setFarm]);
 
+  /** 星露精华：立刻将当前剩余成熟时间减半 */
+  const halvePlotRemainingMatureTime = useCallback((plotId: number): { success: boolean; mutationOutcome?: MutationOutcome } => {
+    const plot = farm.plots.find((p) => p.id === plotId);
+    if (!plot || plot.state !== 'growing' || !plot.varietyId) return { success: false };
+
+    const matureMinutes = VARIETY_DEFS[plot.varietyId]?.matureMinutes ?? 10000;
+    const accumulatedMinutes = Math.max(
+      0,
+      Math.floor(plot.accumulatedMinutes > 0 ? plot.accumulatedMinutes : plot.progress * matureMinutes),
+    );
+    const remainingMinutes = Math.max(0, matureMinutes - accumulatedMinutes);
+    const boostMinutes = Math.min(remainingMinutes, Math.ceil(remainingMinutes / 2));
+    if (boostMinutes <= 0) return { success: false };
+
+    const nowTimestamp = Date.now();
+    const growthResult = updatePlotGrowth(plot, boostMinutes, nowTimestamp);
+    const mutationOutcome = growthResult.mutationOutcome?.status === 'positive' && growthResult.plot.isMutant === true
+      ? growthResult.mutationOutcome
+      : undefined;
+
+    setFarm((prev) => ({
+      ...prev,
+      plots: prev.plots.map((p) => (
+        p.id === plotId && p.state === 'growing' && p.varietyId
+          ? growthResult.plot
+          : p
+      )),
+    }));
+
+    return mutationOutcome ? { success: true, mutationOutcome } : { success: true };
+  }, [farm.plots, setFarm]);
+
   return {
     farm,
     setFarm,
@@ -888,5 +920,6 @@ export function useFarmStorage() {
     markStolenRecordRecovered,
     revivePlot,
     upgradePlotRarity,
+    halvePlotRemainingMatureTime,
   };
 }


### PR DESCRIPTION
## Summary
- add a plot-level `star-dew` action on growing plots using the existing farm affordances
- halve the current remaining mature time as a one-shot immediate growth grant, capped to mature
- keep invalid targets as no-op and avoid introducing any persistent buff state

## Validation
- npm run build
- git diff --check
- npx eslint src/App.tsx src/components/FarmPage.tsx src/components/farm/SimpleFarmGrid.tsx src/hooks/useFarmStorage.ts
- npm run lint *(fails on pre-existing generated file: `android/app/build/intermediates/assets/debug/mergeDebugAssets/native-bridge.js`)*

## Proof
- V2 growing-plot card shows `✨ Star Dew Essence · 2` when inventory is available
- using it on a growing `jade-stripe` moves `accumulatedMinutes` from `4600` to `7301` and updates `farmGrowthTime` from `Grown 3d 4h / 6d 22h needed` to `Grown 5d 1h / 6d 22h needed`
- successful use decrements `star-dew` inventory from `2` to `1`
- mature and empty plots expose no `star-dew` entrance, and inventory remains unchanged on those invalid targets
- mobile `390x844` and desktop `1280x900` both keep the action visible and readable
