### PR TITLE
feat: add farm-wide growth boosts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,9 +70,12 @@ import { getTodayKey } from './utils/time';
 import { getStreak, getDayMinutes } from './utils/stats';
 import {
   applyGrowthWithMutation as applyGrowthWithMutationEngine,
+  calculateFarmGrowthBonusMinutes,
   calculateOfflineGrowth,
   calculateFocusBoost,
   getWitherStatus,
+  isLullabyGrowthBoostActive,
+  isSupernovaBottleGrowthBoostActive,
   type MutationOutcome,
   witherPlots,
 } from './farm/growth';
@@ -122,6 +125,12 @@ import type { DarkMatterFusion, DarkMatterFusionType, FusionResult } from './typ
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const FUSION_HISTORY_KEY = 'watermelon-fusion-history';
 const DEBUG_WEATHER_ORDER: Weather[] = ['sunny', 'cloudy', 'rainy', 'night', 'rainbow', 'snowy', 'stormy'];
+
+interface FarmGrowthSegment {
+  growthMinutes: number;
+  intervalStartTimestamp?: number;
+  intervalEndTimestamp?: number;
+}
 
 function migrateFusionHistory(raw: unknown): FusionHistory {
   if (!raw || typeof raw !== 'object') return DEFAULT_FUSION_HISTORY;
@@ -234,6 +243,8 @@ function App() {
     buyPlot,
     updateActiveDate,
     activateGuardianBarrier,
+    activateLullaby,
+    activateSupernovaBottle,
     addPlotTracker,
     addStolenRecord,
     markStolenRecordRecovered,
@@ -269,6 +280,7 @@ function App() {
   const previousFarmPlotsRef = useRef<Plot[] | null>(null);
   const updatePlotsRef = useRef(updatePlots);
   const growthCarryMinutesRef = useRef(0);
+  const growthBoostCarryMinutesRef = useRef(0);
   const sellingRef = useRef(false);
   const mutationGunMutexRef = useRef(false);
 
@@ -282,6 +294,12 @@ function App() {
 
   useEffect(() => {
     farmPlotsRef.current = farm.plots;
+  }, [farm.plots]);
+
+  useEffect(() => {
+    if (!farm.plots.some((plot) => plot.state === 'growing')) {
+      growthBoostCarryMinutesRef.current = 0;
+    }
   }, [farm.plots]);
 
   useEffect(() => {
@@ -468,18 +486,87 @@ function App() {
     previousFarmPlotsRef.current = farm.plots;
   }, [farm.plots, enqueueRecoveryToast, t]);
 
+  const resolveFarmGrowthMinutes = useCallback((
+    plots: Plot[],
+    segment: FarmGrowthSegment,
+  ) => {
+    const safeGrowthMinutes = Number.isFinite(segment.growthMinutes)
+      ? Math.max(0, segment.growthMinutes)
+      : 0;
+    if (safeGrowthMinutes <= 0) return 0;
+
+    const hasGrowingPlots = plots.some((plot) => plot.state === 'growing');
+    if (!hasGrowingPlots) {
+      growthBoostCarryMinutesRef.current = 0;
+      return Math.floor(safeGrowthMinutes);
+    }
+
+    const safeEndTimestamp = Number.isFinite(segment.intervalEndTimestamp) && (segment.intervalEndTimestamp ?? 0) > 0
+      ? (segment.intervalEndTimestamp as number)
+      : Date.now();
+    const fallbackStartTimestamp = safeEndTimestamp - safeGrowthMinutes * 60 * 1000;
+    const safeStartTimestamp = Number.isFinite(segment.intervalStartTimestamp) && (segment.intervalStartTimestamp ?? 0) > 0
+      ? Math.min(segment.intervalStartTimestamp as number, safeEndTimestamp)
+      : fallbackStartTimestamp;
+
+    const bonusGrowthMinutes = calculateFarmGrowthBonusMinutes(
+      safeGrowthMinutes,
+      safeStartTimestamp,
+      safeEndTimestamp,
+      farm.lullabyActivatedAt,
+      farm.supernovaBottleActivatedAt,
+    );
+    const rawGrowthMinutes = safeGrowthMinutes + bonusGrowthMinutes + growthBoostCarryMinutesRef.current;
+    const appliedGrowthMinutes = Math.max(0, Math.floor(rawGrowthMinutes));
+    growthBoostCarryMinutesRef.current = rawGrowthMinutes - appliedGrowthMinutes;
+    return appliedGrowthMinutes;
+  }, [farm.lullabyActivatedAt, farm.supernovaBottleActivatedAt]);
+
   const runFarmGrowth = useCallback((
     plots: Plot[],
-    growthMinutes: number,
+    segments: FarmGrowthSegment[],
     nowTimestamp: number,
     enableThiefRoll: boolean = true,
-  ) => applyGrowthWithMutationEngine(plots, growthMinutes, {
-    nowTimestamp,
-    todayKey,
-    focusMinutesToday: todayFocusMinutes,
-    guardianBarrierDate: farm.guardianBarrierDate,
-    enableThiefRoll,
-  }), [todayKey, todayFocusMinutes, farm.guardianBarrierDate]);
+  ) => {
+    const activeSegments = segments.filter((segment) => (
+      Number.isFinite(segment.growthMinutes) && segment.growthMinutes > 0
+    ));
+
+    if (activeSegments.length === 0) {
+      return applyGrowthWithMutationEngine(plots, 0, {
+        nowTimestamp,
+        todayKey,
+        focusMinutesToday: todayFocusMinutes,
+        guardianBarrierDate: farm.guardianBarrierDate,
+        enableThiefRoll,
+      });
+    }
+
+    let nextPlots = plots;
+    const mutationToasts: MutationOutcome[] = [];
+    const stolenRecords: import('./types/farm').StolenRecord[] = [];
+    const lastSegmentIndex = activeSegments.length - 1;
+
+    activeSegments.forEach((segment, index) => {
+      const adjustedGrowthMinutes = resolveFarmGrowthMinutes(nextPlots, segment);
+      const result = applyGrowthWithMutationEngine(nextPlots, adjustedGrowthMinutes, {
+        nowTimestamp,
+        todayKey,
+        focusMinutesToday: todayFocusMinutes,
+        guardianBarrierDate: farm.guardianBarrierDate,
+        enableThiefRoll: enableThiefRoll && index === lastSegmentIndex,
+      });
+      nextPlots = result.plots;
+      mutationToasts.push(...result.mutationToasts);
+      stolenRecords.push(...result.stolenRecords);
+    });
+
+    return {
+      plots: nextPlots,
+      mutationToasts,
+      stolenRecords,
+    };
+  }, [todayKey, todayFocusMinutes, farm.guardianBarrierDate, resolveFarmGrowthMinutes]);
 
   useEffect(() => {
     const previousFocusMinutes = appliedFocusMinutesRef.current;
@@ -500,9 +587,14 @@ function App() {
     if (focusBoostMinutes <= 0) return;
 
     const nowTimestamp = Date.now();
+    const focusIntervalStartTimestamp = nowTimestamp - deltaFocusMinutes * 60 * 1000;
     const { plots: newPlots, mutationToasts, stolenRecords } = runFarmGrowth(
       farmPlotsRef.current,
-      focusBoostMinutes * timeMultiplierRef.current,
+      [{
+        growthMinutes: focusBoostMinutes * timeMultiplierRef.current,
+        intervalStartTimestamp: focusIntervalStartTimestamp,
+        intervalEndTimestamp: nowTimestamp,
+      }],
       nowTimestamp,
     );
     updatePlotsRef.current(newPlots);
@@ -517,7 +609,7 @@ function App() {
       // First visit or same day — still settle overdue thief countdown once.
       const { plots: settledPlots, stolenRecords } = runFarmGrowth(
         farm.plots,
-        0,
+        [],
         nowTimestamp,
         false,
       );
@@ -547,11 +639,32 @@ function App() {
       updatePlots(witherPlots(farm.plots, nowTimestamp, effectiveLastActivityTs));
       updateActiveDate(todayKey, witherStatus.inactiveDays, nowTimestamp);
     } else {
-      // Apply minute-based growth: offline growth + focus boost
+      // Apply offline growth and focus boost separately so boost windows can clip each segment correctly.
       const offlineGrowthMinutes = calculateOfflineGrowth(witherStatus.inactiveMinutes);
       const focusBoostMinutes = calculateFocusBoost(todayFocusMinutes);
-      const totalGrowthMinutes = (offlineGrowthMinutes + focusBoostMinutes) * timeMultiplierRef.current;
-      const { plots: newPlots, mutationToasts, stolenRecords } = runFarmGrowth(farm.plots, totalGrowthMinutes, nowTimestamp);
+      const growthSegments: FarmGrowthSegment[] = [];
+
+      if (offlineGrowthMinutes > 0) {
+        growthSegments.push({
+          growthMinutes: offlineGrowthMinutes * timeMultiplierRef.current,
+          intervalStartTimestamp: effectiveLastActivityTs,
+          intervalEndTimestamp: effectiveLastActivityTs + offlineGrowthMinutes * 60 * 1000,
+        });
+      }
+
+      if (focusBoostMinutes > 0) {
+        growthSegments.push({
+          growthMinutes: focusBoostMinutes * timeMultiplierRef.current,
+          intervalStartTimestamp: nowTimestamp - todayFocusMinutes * 60 * 1000,
+          intervalEndTimestamp: nowTimestamp,
+        });
+      }
+
+      const { plots: newPlots, mutationToasts, stolenRecords } = runFarmGrowth(
+        farm.plots,
+        growthSegments,
+        nowTimestamp,
+      );
       updatePlots(newPlots);
       enqueueMutationToasts(mutationToasts);
       stolenRecords.forEach(addStolenRecord);
@@ -569,9 +682,16 @@ function App() {
       if (minutesPerTick <= 0) return;
 
       const nowTimestamp = Date.now();
+      const intervalDurationMs = timeMultiplier > 0
+        ? (minutesPerTick / timeMultiplier) * 60 * 1000
+        : minutesPerTick * 60 * 1000;
       const { plots: newPlots, mutationToasts, stolenRecords } = runFarmGrowth(
         farmPlotsRef.current,
-        minutesPerTick,
+        [{
+          growthMinutes: minutesPerTick,
+          intervalStartTimestamp: nowTimestamp - intervalDurationMs,
+          intervalEndTimestamp: nowTimestamp,
+        }],
         nowTimestamp,
         false,
       );
@@ -589,7 +709,7 @@ function App() {
       const nowTimestamp = Date.now();
       const { plots: newPlots, stolenRecords } = runFarmGrowth(
         farmPlotsRef.current,
-        0,
+        [],
         nowTimestamp,
         false,
       );
@@ -734,6 +854,32 @@ function App() {
       addCoins(price);
     }
   }, [farm.unlockedPlotCount, spendCoins, buyPlot, addCoins]);
+
+  const handleUseLullaby = useCallback(() => {
+    const nowTimestamp = Date.now();
+    if (isLullabyGrowthBoostActive(farm.lullabyActivatedAt, nowTimestamp)) return;
+
+    const consumed = consumeShopItem('lullaby');
+    if (!consumed) return;
+
+    const activated = activateLullaby(nowTimestamp);
+    if (!activated) {
+      addShedItem('lullaby', 1);
+    }
+  }, [farm.lullabyActivatedAt, consumeShopItem, activateLullaby, addShedItem]);
+
+  const handleUseSupernovaBottle = useCallback(() => {
+    const nowTimestamp = Date.now();
+    if (isSupernovaBottleGrowthBoostActive(farm.supernovaBottleActivatedAt, nowTimestamp)) return;
+
+    const consumed = consumeShopItem('supernova-bottle');
+    if (!consumed) return;
+
+    const activated = activateSupernovaBottle(nowTimestamp);
+    if (!activated) {
+      addShedItem('supernova-bottle', 1);
+    }
+  }, [farm.supernovaBottleActivatedAt, consumeShopItem, activateSupernovaBottle, addShedItem]);
 
   const handleUseMutationGun = useCallback((plotId: number) => {
     if (mutationGunMutexRef.current) return;
@@ -1904,6 +2050,8 @@ function App() {
             onPlantDarkMatter={handleFarmPlantDarkMatter}
             onHarvest={handleFarmHarvest}
             onClear={clearPlot}
+            onUseLullaby={handleUseLullaby}
+            onUseSupernovaBottle={handleUseSupernovaBottle}
             onUseMutationGun={handleUseMutationGun}
             onUseMoonDew={handleUseMoonDew}
             onUseStarDew={handleUseStarDew}

--- a/src/components/FarmPage.tsx
+++ b/src/components/FarmPage.tsx
@@ -28,7 +28,13 @@ import type {
   ItemId,
 } from '../types/slicing';
 import { VARIETY_DEFS, RARITY_COLOR, RARITY_STARS } from '../types/farm';
-import { getGrowthStage, isVarietyRevealed } from '../farm/growth';
+import {
+  getGrowthStage,
+  getSupernovaBottleGrowthBoostEndTimestamp,
+  isLullabyGrowthBoostActive,
+  isSupernovaBottleGrowthBoostActive,
+  isVarietyRevealed,
+} from '../farm/growth';
 import { CollectionPage } from './CollectionPage';
 import { GeneLabPage } from './GeneLabPage';
 import { SimpleFarmGrid } from './farm/SimpleFarmGrid';
@@ -67,6 +73,8 @@ interface FarmPageProps {
     rewardSeedQuality?: SeedQuality;
   };
   onClear: (plotId: number) => void;
+  onUseLullaby: () => void;
+  onUseSupernovaBottle: () => void;
   onUseMutationGun: (plotId: number) => void;
   onUseMoonDew: (plotId: number) => void;
   onUseStarDew: (plotId: number) => void;
@@ -123,6 +131,8 @@ export function FarmPage({
   fusionHistory,
   onHarvest,
   onClear,
+  onUseLullaby,
+  onUseSupernovaBottle,
   onUseMutationGun,
   onUseMoonDew,
   onUseStarDew,
@@ -255,6 +265,8 @@ export function FarmPage({
     () => farm.plots.filter((plot) => plot.state === 'mature').length,
     [farm.plots],
   );
+  const lullabyCount = (items as Record<string, number>).lullaby ?? 0;
+  const supernovaBottleCount = (items as Record<string, number>)['supernova-bottle'] ?? 0;
   const mutationGunCount = (items as Record<string, number>)['mutation-gun'] ?? 0;
   const moonDewCount = (items as Record<string, number>)['moon-dew'] ?? 0;
   const starDewCount = (items as Record<string, number>)['star-dew'] ?? 0;
@@ -262,6 +274,17 @@ export function FarmPage({
   const starTrackerCount = (items as Record<string, number>)['star-tracker'] ?? 0;
   const guardianBarrierCount = (items as Record<string, number>)['guardian-barrier'] ?? 0;
   const trapNetCount = (items as Record<string, number>)['trap-net'] ?? 0;
+  const lullabyActive = isLullabyGrowthBoostActive(farm.lullabyActivatedAt, nowTimestamp);
+  const supernovaBottleActive = isSupernovaBottleGrowthBoostActive(
+    farm.supernovaBottleActivatedAt,
+    nowTimestamp,
+  );
+  const supernovaBottleRemainingMinutes = supernovaBottleActive
+    ? Math.max(
+        1,
+        Math.ceil((getSupernovaBottleGrowthBoostEndTimestamp(farm.supernovaBottleActivatedAt) - nowTimestamp) / 60000),
+      )
+    : 0;
   const barrierActiveToday = farm.guardianBarrierDate === todayKey;
   const canUseActivePlotStarDew = Boolean(activeGrowingPlot?.varietyId) && starDewCount > 0;
 
@@ -379,6 +402,60 @@ export function FarmPage({
 
           {/* 道具快捷栏 */}
           <div className="flex items-center gap-2 overflow-x-auto no-scrollbar pb-1">
+            {(lullabyCount > 0 || lullabyActive) && (
+              <button
+                type="button"
+                onClick={onUseLullaby}
+                disabled={lullabyActive}
+                data-testid="farm-lullaby-boost-chip"
+                data-active={lullabyActive ? 'true' : 'false'}
+                className="shrink-0 flex items-center gap-2 px-3 py-2 rounded-[var(--radius-sm)] border text-xs font-medium transition-all duration-200 ease-in-out hover:-translate-y-0.5 ui-hover-button disabled:hover:translate-y-0"
+                style={{
+                  background: lullabyActive
+                    ? 'linear-gradient(135deg, rgba(241,255,220,0.95) 0%, rgba(217,244,170,0.95) 100%)'
+                    : `${theme.surface}cc`,
+                  borderColor: lullabyActive ? '#84cc16' : theme.border,
+                  color: lullabyActive ? '#47611b' : theme.text,
+                  boxShadow: 'var(--shadow-card)',
+                  cursor: lullabyActive ? 'default' : 'pointer',
+                }}
+                title={t.itemDescription('lullaby')}
+              >
+                <span>🎵</span>
+                <span>
+                  {lullabyActive
+                    ? `${t.itemName('lullaby')} · +30% · ${t.today}`
+                    : `${t.itemName('lullaby')} · ${lullabyCount}`}
+                </span>
+              </button>
+            )}
+            {(supernovaBottleCount > 0 || supernovaBottleActive) && (
+              <button
+                type="button"
+                onClick={onUseSupernovaBottle}
+                disabled={supernovaBottleActive}
+                data-testid="farm-supernova-boost-chip"
+                data-active={supernovaBottleActive ? 'true' : 'false'}
+                className="shrink-0 flex items-center gap-2 px-3 py-2 rounded-[var(--radius-sm)] border text-xs font-medium transition-all duration-200 ease-in-out hover:-translate-y-0.5 ui-hover-button disabled:hover:translate-y-0"
+                style={{
+                  background: supernovaBottleActive
+                    ? 'linear-gradient(135deg, rgba(255,238,196,0.97) 0%, rgba(255,198,109,0.95) 100%)'
+                    : `${theme.surface}cc`,
+                  borderColor: supernovaBottleActive ? '#f97316' : theme.border,
+                  color: supernovaBottleActive ? '#8a3b12' : theme.text,
+                  boxShadow: 'var(--shadow-card)',
+                  cursor: supernovaBottleActive ? 'default' : 'pointer',
+                }}
+                title={t.itemDescription('supernova-bottle')}
+              >
+                <span>💥</span>
+                <span>
+                  {supernovaBottleActive
+                    ? `${t.itemName('supernova-bottle')} · +50% · ${t.formatDuration(supernovaBottleRemainingMinutes)}`
+                    : `${t.itemName('supernova-bottle')} · ${supernovaBottleCount}`}
+                </span>
+              </button>
+            )}
             {(guardianBarrierCount > 0 || barrierActiveToday) && (
               <button
                 onClick={onUseGuardianBarrier}

--- a/src/farm/growth.ts
+++ b/src/farm/growth.ts
@@ -18,6 +18,101 @@ const PRISMATIC_REWIND_MAX = 0.50;
 const MUTATION_TRIGGER_PROGRESS = 0.20;
 const THIEF_STEAL_DELAY_MINUTES = 30;
 const THIEF_STEAL_DELAY_MS = THIEF_STEAL_DELAY_MINUTES * 60 * 1000;
+const DAY_IN_MS = MINUTES_PER_DAY * 60 * 1000;
+
+export const LULLABY_FARM_GROWTH_BONUS_RATE = 0.30;
+export const SUPERNOVA_BOTTLE_FARM_GROWTH_BONUS_RATE = 0.50;
+export const SUPERNOVA_BOTTLE_DURATION_MS = DAY_IN_MS;
+
+function getLocalDayEndTimestamp(timestamp: number): number {
+  const dayEnd = new Date(timestamp);
+  dayEnd.setHours(24, 0, 0, 0);
+  return dayEnd.getTime();
+}
+
+function getTimeOverlapMs(
+  rangeStart: number,
+  rangeEnd: number,
+  windowStart: number,
+  windowEnd: number,
+): number {
+  return Math.max(0, Math.min(rangeEnd, windowEnd) - Math.max(rangeStart, windowStart));
+}
+
+function getLullabyGrowthBoostWindow(activatedAt: number): { start: number; end: number } | null {
+  if (!Number.isFinite(activatedAt) || activatedAt <= 0) return null;
+  return {
+    start: activatedAt,
+    end: getLocalDayEndTimestamp(activatedAt),
+  };
+}
+
+function getSupernovaBottleGrowthBoostWindow(activatedAt: number): { start: number; end: number } | null {
+  if (!Number.isFinite(activatedAt) || activatedAt <= 0) return null;
+  return {
+    start: activatedAt,
+    end: activatedAt + SUPERNOVA_BOTTLE_DURATION_MS,
+  };
+}
+
+export function getSupernovaBottleGrowthBoostEndTimestamp(activatedAt: number): number {
+  return getSupernovaBottleGrowthBoostWindow(activatedAt)?.end ?? 0;
+}
+
+export function isLullabyGrowthBoostActive(
+  activatedAt: number,
+  nowTimestamp: number = Date.now(),
+): boolean {
+  const window = getLullabyGrowthBoostWindow(activatedAt);
+  if (!window) return false;
+  return nowTimestamp >= window.start && nowTimestamp < window.end;
+}
+
+export function isSupernovaBottleGrowthBoostActive(
+  activatedAt: number,
+  nowTimestamp: number = Date.now(),
+): boolean {
+  const window = getSupernovaBottleGrowthBoostWindow(activatedAt);
+  if (!window) return false;
+  return nowTimestamp >= window.start && nowTimestamp < window.end;
+}
+
+export function calculateFarmGrowthBonusMinutes(
+  baseGrowthMinutes: number,
+  intervalStartTimestamp: number,
+  intervalEndTimestamp: number,
+  lullabyActivatedAt: number,
+  supernovaBottleActivatedAt: number,
+): number {
+  const safeBaseGrowthMinutes = Number.isFinite(baseGrowthMinutes) ? Math.max(0, baseGrowthMinutes) : 0;
+  if (safeBaseGrowthMinutes <= 0) return 0;
+
+  const safeEndTimestamp = Number.isFinite(intervalEndTimestamp) && intervalEndTimestamp > 0
+    ? intervalEndTimestamp
+    : Date.now();
+  const fallbackStartTimestamp = safeEndTimestamp - safeBaseGrowthMinutes * 60 * 1000;
+  const safeStartTimestamp = Number.isFinite(intervalStartTimestamp) && intervalStartTimestamp > 0
+    ? Math.min(intervalStartTimestamp, safeEndTimestamp)
+    : fallbackStartTimestamp;
+  const intervalDurationMs = Math.max(1, safeEndTimestamp - safeStartTimestamp);
+
+  const lullabyOverlapMs = (() => {
+    const window = getLullabyGrowthBoostWindow(lullabyActivatedAt);
+    if (!window) return 0;
+    return getTimeOverlapMs(safeStartTimestamp, safeEndTimestamp, window.start, window.end);
+  })();
+
+  const supernovaOverlapMs = (() => {
+    const window = getSupernovaBottleGrowthBoostWindow(supernovaBottleActivatedAt);
+    if (!window) return 0;
+    return getTimeOverlapMs(safeStartTimestamp, safeEndTimestamp, window.start, window.end);
+  })();
+
+  const weightedBonusRate = (lullabyOverlapMs / intervalDurationMs) * LULLABY_FARM_GROWTH_BONUS_RATE
+    + (supernovaOverlapMs / intervalDurationMs) * SUPERNOVA_BOTTLE_FARM_GROWTH_BONUS_RATE;
+
+  return safeBaseGrowthMinutes * weightedBonusRate;
+}
 
 /**
  * 星际大盗出现概率（按当天专注分钟）：

--- a/src/hooks/useFarmStorage.ts
+++ b/src/hooks/useFarmStorage.ts
@@ -28,7 +28,13 @@ import {
 } from '../types/farm';
 import { DEFAULT_SEED_COUNTS } from '../types/slicing';
 import { getPlotCount } from '../farm/galaxy';
-import { rollVariety, updatePlotGrowth, type MutationOutcome } from '../farm/growth';
+import {
+  isLullabyGrowthBoostActive,
+  isSupernovaBottleGrowthBoostActive,
+  rollVariety,
+  updatePlotGrowth,
+  type MutationOutcome,
+} from '../farm/growth';
 
 const FARM_KEY = 'watermelon-farm';
 const MAX_PLOT_COUNT = 9;
@@ -396,6 +402,8 @@ function migrateFarm(raw: unknown): FarmStorage {
     consecutiveInactiveDays: 0,
     lastActivityTimestamp: 0,
     guardianBarrierDate: '',
+    lullabyActivatedAt: 0,
+    supernovaBottleActivatedAt: 0,
     stolenRecords: [],
   };
   const storedUnlockedPlotCount = typeof s.unlockedPlotCount === 'number' && Number.isFinite(s.unlockedPlotCount)
@@ -488,6 +496,12 @@ function migrateFarm(raw: unknown): FarmStorage {
   if (typeof s.consecutiveInactiveDays === 'number') result.consecutiveInactiveDays = s.consecutiveInactiveDays;
   if (typeof s.lastActivityTimestamp === 'number') result.lastActivityTimestamp = s.lastActivityTimestamp;
   if (typeof s.guardianBarrierDate === 'string') result.guardianBarrierDate = s.guardianBarrierDate;
+  if (typeof s.lullabyActivatedAt === 'number' && Number.isFinite(s.lullabyActivatedAt)) {
+    result.lullabyActivatedAt = Math.max(0, s.lullabyActivatedAt);
+  }
+  if (typeof s.supernovaBottleActivatedAt === 'number' && Number.isFinite(s.supernovaBottleActivatedAt)) {
+    result.supernovaBottleActivatedAt = Math.max(0, s.supernovaBottleActivatedAt);
+  }
   if (Array.isArray(s.stolenRecords)) {
     result.stolenRecords = s.stolenRecords
       .map((record) => normalizeStolenRecord(record))
@@ -774,6 +788,34 @@ export function useFarmStorage() {
     return true;
   }, [setFarm]);
 
+  /** 激活原初摇篮曲（当天有效） */
+  const activateLullaby = useCallback((nowTimestamp: number = Date.now()): boolean => {
+    if (!Number.isFinite(nowTimestamp) || nowTimestamp <= 0) return false;
+    if (isLullabyGrowthBoostActive(farmRef.current.lullabyActivatedAt, nowTimestamp)) return false;
+
+    const nextFarm: FarmStorage = {
+      ...farmRef.current,
+      lullabyActivatedAt: nowTimestamp,
+    };
+    farmRef.current = nextFarm;
+    setFarm(nextFarm);
+    return true;
+  }, [setFarm]);
+
+  /** 激活超新星之瓶（24 小时有效） */
+  const activateSupernovaBottle = useCallback((nowTimestamp: number = Date.now()): boolean => {
+    if (!Number.isFinite(nowTimestamp) || nowTimestamp <= 0) return false;
+    if (isSupernovaBottleGrowthBoostActive(farmRef.current.supernovaBottleActivatedAt, nowTimestamp)) return false;
+
+    const nextFarm: FarmStorage = {
+      ...farmRef.current,
+      supernovaBottleActivatedAt: nowTimestamp,
+    };
+    farmRef.current = nextFarm;
+    setFarm(nextFarm);
+    return true;
+  }, [setFarm]);
+
   /** 为地块安装星际追踪器 */
   const addPlotTracker = useCallback((plotId: number): boolean => {
     const plot = farm.plots.find((p) => p.id === plotId);
@@ -915,6 +957,8 @@ export function useFarmStorage() {
     buyPlot,
     updateActiveDate,
     activateGuardianBarrier,
+    activateLullaby,
+    activateSupernovaBottle,
     addPlotTracker,
     addStolenRecord,
     markStolenRecordRecovered,

--- a/src/types/farm.ts
+++ b/src/types/farm.ts
@@ -749,6 +749,8 @@ export interface FarmStorage {
   consecutiveInactiveDays: number; // 连续未活跃天数（用于枯萎检测）
   lastActivityTimestamp: number; // 最近活跃时间戳（ms）
   guardianBarrierDate: string; // 守护结界生效日期 (YYYY-MM-DD)
+  lullabyActivatedAt: number; // 原初摇篮曲激活时间（ms）
+  supernovaBottleActivatedAt: number; // 超新星之瓶激活时间（ms）
   stolenRecords: StolenRecord[]; // 用于追回机制
 }
 
@@ -787,6 +789,8 @@ export const DEFAULT_FARM_STORAGE: FarmStorage = {
   consecutiveInactiveDays: 0,
   lastActivityTimestamp: 0,
   guardianBarrierDate: '',
+  lullabyActivatedAt: 0,
+  supernovaBottleActivatedAt: 0,
   stolenRecords: [],
 };
 


### PR DESCRIPTION
## Summary
- add farm-wide quick-bar boosts for `lullaby` and `supernova-bottle`
- apply their +30% / +50% bonuses through the existing growth-minute pipeline with additive stacking and real window clipping
- persist the two explicit farm-level boost states without introducing a generic buff framework

## Validation
- npm run build
- git diff --check
- npx eslint src/App.tsx src/components/FarmPage.tsx src/farm/growth.ts src/hooks/useFarmStorage.ts src/types/farm.ts
- npm run lint *(fails on pre-existing generated file: `android/app/build/intermediates/assets/debug/mergeDebugAssets/native-bridge.js`)*

## Proof
- farm quick-bar shows both entrances: `Primordial Lullaby · 1` and `Supernova Bottle · 1`
- using each chip consumes inventory, flips to active/disabled state, and persists after reload
- same 60-minute baseline produces `60` (no boost), `78` (lullaby), `90` (supernova), and `108` (both active)
- a 4h offline interval with supernova activated 26h ago settles to `300` minutes total, so only the 2h pre-expiry overlap receives the +50% bonus
- desktop `1280x800` and mobile `390x844` both keep the quick-bar chips readable and usable
