### PR TITLE
fix: restore drift bottle summon path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -329,7 +329,7 @@ function App() {
     () => farm.plots.filter((plot) => plot.state === 'growing' || plot.state === 'mature').length,
     [farm.plots],
   );
-  const { alienVisit } = useAlienVisit({
+  const { alienVisit, summonDriftBottleVisit } = useAlienVisit({
     plantedMelonCount,
     todayKey,
     mutationDoctorSignal,
@@ -1004,6 +1004,16 @@ function App() {
     consumeShopItem('guardian-barrier');
     enqueueRecoveryToast(t.itemGuardianBarrierActive);
   }, [farm.guardianBarrierDate, farm.plots, shed.items, todayKey, consumeShopItem, activateGuardianBarrier, enqueueRecoveryToast, t]);
+
+  const handleUseDriftBottle = useCallback(() => {
+    const consumed = consumeShopItem('drift-bottle');
+    if (!consumed) return;
+
+    const summoned = summonDriftBottleVisit();
+    if (!summoned) {
+      addShedItem('drift-bottle', 1);
+    }
+  }, [consumeShopItem, summonDriftBottleVisit, addShedItem]);
 
   const handleUseTrapNet = useCallback((plotId: number) => {
     const targetPlot = farm.plots.find((p) => p.id === plotId);
@@ -2098,6 +2108,7 @@ function App() {
             onUseNectar={handleUseNectar}
             onUseStarTracker={handleUseStarTracker}
             onUseGuardianBarrier={handleUseGuardianBarrier}
+            onUseDriftBottle={handleUseDriftBottle}
             onUseTrapNet={handleUseTrapNet}
             onInject={handleGeneInject}
             onFusion={handleGeneFusion}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1006,14 +1006,16 @@ function App() {
   }, [farm.guardianBarrierDate, farm.plots, shed.items, todayKey, consumeShopItem, activateGuardianBarrier, enqueueRecoveryToast, t]);
 
   const handleUseDriftBottle = useCallback(() => {
-    const consumed = consumeShopItem('drift-bottle');
-    if (!consumed) return;
+    const driftBottleCount = (shed.items as Record<string, number>)['drift-bottle'] ?? 0;
+    if (driftBottleCount <= 0) return;
 
     const summoned = summonDriftBottleVisit();
     if (!summoned) {
-      addShedItem('drift-bottle', 1);
+      return;
     }
-  }, [consumeShopItem, summonDriftBottleVisit, addShedItem]);
+
+    consumeShopItem('drift-bottle');
+  }, [shed.items, summonDriftBottleVisit, consumeShopItem]);
 
   const handleUseTrapNet = useCallback((plotId: number) => {
     const targetPlot = farm.plots.find((p) => p.id === plotId);

--- a/src/components/FarmPage.tsx
+++ b/src/components/FarmPage.tsx
@@ -88,6 +88,7 @@ interface FarmPageProps {
   onUseNectar: (plotId: number) => void;
   onUseStarTracker: (plotId: number) => void;
   onUseGuardianBarrier: () => void;
+  onUseDriftBottle: () => void;
   onUseTrapNet: (plotId: number) => void;
   onGoWarehouse: () => void;
   compactShell?: boolean;
@@ -181,6 +182,7 @@ export function FarmPage({
   onUseNectar,
   onUseStarTracker,
   onUseGuardianBarrier,
+  onUseDriftBottle,
   onUseTrapNet,
   onGoWarehouse,
   compactShell = false,
@@ -320,6 +322,7 @@ export function FarmPage({
   const nectarCount = (items as Record<string, number>)['nectar'] ?? 0;
   const starTrackerCount = (items as Record<string, number>)['star-tracker'] ?? 0;
   const guardianBarrierCount = (items as Record<string, number>)['guardian-barrier'] ?? 0;
+  const driftBottleCount = (items as Record<string, number>)['drift-bottle'] ?? 0;
   const trapNetCount = (items as Record<string, number>)['trap-net'] ?? 0;
   const crystalBallCount = (items as Record<string, number>)['crystal-ball'] ?? 0;
   const crystalBallPendingVarietyName = pendingRevealedNormalSeed
@@ -342,6 +345,7 @@ export function FarmPage({
   const activeAlienSceneVisit = activeAlienVisit && activeAlienVisit.expiresAt > nowTimestamp
     ? activeAlienVisit
     : null;
+  const driftBottleDisabled = Boolean(activeAlienSceneVisit);
 
   const latestStolenRecordByPlotId = useMemo(() => {
     const latestByPlot = new Map<number, StolenRecord>();
@@ -573,6 +577,29 @@ export function FarmPage({
               >
                 <span>🎪</span>
                 <span>{barrierActiveToday ? t.itemGuardianBarrierActive : `${t.itemName('guardian-barrier')} · ${guardianBarrierCount}`}</span>
+              </button>
+            )}
+            {driftBottleCount > 0 && (
+              <button
+                type="button"
+                onClick={onUseDriftBottle}
+                disabled={driftBottleDisabled}
+                data-testid="farm-drift-bottle-chip"
+                className="shrink-0 flex items-center gap-2 px-3 py-2 rounded-[var(--radius-sm)] border text-xs font-medium transition-all duration-200 ease-in-out hover:-translate-y-0.5 ui-hover-button disabled:hover:translate-y-0"
+                style={{
+                  background: driftBottleDisabled
+                    ? `${theme.surface}cc`
+                    : `${theme.accent}18`,
+                  borderColor: driftBottleDisabled ? theme.border : theme.accent,
+                  color: driftBottleDisabled ? theme.textMuted : theme.accent,
+                  boxShadow: 'var(--shadow-card)',
+                  cursor: driftBottleDisabled ? 'not-allowed' : 'pointer',
+                  opacity: driftBottleDisabled ? 0.72 : 1,
+                }}
+                title={t.itemDescription('drift-bottle')}
+              >
+                <span>🍾</span>
+                <span>{`${t.itemName('drift-bottle')} · ${driftBottleCount}`}</span>
               </button>
             )}
             {trapNetCount > 0 && (

--- a/src/hooks/useAlienVisit.ts
+++ b/src/hooks/useAlienVisit.ts
@@ -178,26 +178,31 @@ export function useAlienVisit({ plantedMelonCount, todayKey, mutationDoctorSigna
       return false;
     }
 
-    const cleanedVisit = clearExpiredAppearance(alienVisit, now);
-
-    if (cleanedVisit.current && cleanedVisit.current.expiresAt > now) {
-      activeAlienExpiresAtRef.current = cleanedVisit.current.expiresAt;
-      return false;
-    }
-
     const candidate = DRIFT_BOTTLE_SUMMON_CANDIDATES[
       Math.floor(Math.random() * DRIFT_BOTTLE_SUMMON_CANDIDATES.length)
     ];
     const idSuffix = Math.random().toString(36).slice(2, 8);
     const appearance = createAppearance(candidate.type, candidate.messageKey, now, idSuffix);
-    activeAlienExpiresAtRef.current = appearance.expiresAt;
+    let success = false;
 
-    setAlienVisit({
-      ...cleanedVisit,
-      current: appearance,
+    setAlienVisit((prev) => {
+      const cleanedVisit = clearExpiredAppearance(prev, now);
+
+      if (cleanedVisit.current && cleanedVisit.current.expiresAt > now) {
+        activeAlienExpiresAtRef.current = cleanedVisit.current.expiresAt;
+        return cleanedVisit;
+      }
+
+      activeAlienExpiresAtRef.current = appearance.expiresAt;
+      success = true;
+      return {
+        ...cleanedVisit,
+        current: appearance,
+      };
     });
-    return true;
-  }, [alienVisit, setAlienVisit]);
+
+    return success;
+  }, [setAlienVisit]);
 
   return {
     alienVisit,

--- a/src/hooks/useAlienVisit.ts
+++ b/src/hooks/useAlienVisit.ts
@@ -96,11 +96,21 @@ export function useAlienVisit({ plantedMelonCount, todayKey, mutationDoctorSigna
   );
   const previousSignalRef = useRef(mutationDoctorSignal);
   const currentAlienExpiresAt = alienVisit.current?.expiresAt;
+  const alienVisitRef = useRef(alienVisit);
   const activeAlienExpiresAtRef = useRef(currentAlienExpiresAt ?? 0);
 
   useEffect(() => {
+    alienVisitRef.current = alienVisit;
     activeAlienExpiresAtRef.current = currentAlienExpiresAt ?? 0;
-  }, [currentAlienExpiresAt]);
+  }, [alienVisit, currentAlienExpiresAt]);
+
+  const applyAlienVisitUpdate = useCallback((updater: (prev: AlienVisit) => AlienVisit) => {
+    const next = updater(alienVisitRef.current);
+    alienVisitRef.current = next;
+    setAlienVisit(next);
+    activeAlienExpiresAtRef.current = next.current?.expiresAt ?? 0;
+    return next;
+  }, [setAlienVisit]);
 
   // App open / day check: melon alien appears with 10% chance when 3+ melons exist.
   useEffect(() => {
@@ -109,7 +119,7 @@ export function useAlienVisit({ plantedMelonCount, todayKey, mutationDoctorSigna
     const now = Date.now();
     const melonAlienChanceRoll = Math.random();
     const melonAlienIdSuffix = Math.random().toString(36).slice(2, 8);
-    setAlienVisit((prev) => {
+    applyAlienVisitUpdate((prev) => {
       const cleaned = clearExpiredAppearance(prev, now);
 
       if (plantedMelonCount < 3) {
@@ -133,7 +143,7 @@ export function useAlienVisit({ plantedMelonCount, todayKey, mutationDoctorSigna
         current: createAppearance('melon-alien', 'alienMelonGreeting', now, melonAlienIdSuffix),
       };
     });
-  }, [plantedMelonCount, todayKey, setAlienVisit]);
+  }, [plantedMelonCount, todayKey, applyAlienVisitUpdate]);
 
   // Mutation doctor: 15% chance when gene modifier is consumed.
   useEffect(() => {
@@ -148,29 +158,29 @@ export function useAlienVisit({ plantedMelonCount, todayKey, mutationDoctorSigna
 
     const now = Date.now();
     const mutationDoctorIdSuffix = Math.random().toString(36).slice(2, 8);
-    setAlienVisit((prev) => ({
+    applyAlienVisitUpdate((prev) => ({
       ...clearExpiredAppearance(prev, now),
       current: createAppearance('mutation-doctor', 'alienMutationDoctor', now, mutationDoctorIdSuffix),
     }));
-  }, [mutationDoctorSignal, setAlienVisit]);
+  }, [mutationDoctorSignal, applyAlienVisitUpdate]);
 
   // Auto-hide active alien bubble after 3 seconds.
   useEffect(() => {
     if (!currentAlienExpiresAt) return;
     const remainingMs = currentAlienExpiresAt - Date.now();
     if (remainingMs <= 0) {
-      setAlienVisit((prev) => clearExpiredAppearance(prev, Date.now()));
+      applyAlienVisitUpdate((prev) => clearExpiredAppearance(prev, Date.now()));
       return;
     }
 
     const timeoutId = window.setTimeout(() => {
-      setAlienVisit((prev) => clearExpiredAppearance(prev, Date.now()));
+      applyAlienVisitUpdate((prev) => clearExpiredAppearance(prev, Date.now()));
     }, remainingMs + 10);
 
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [currentAlienExpiresAt, setAlienVisit]);
+  }, [currentAlienExpiresAt, applyAlienVisitUpdate]);
 
   const summonDriftBottleVisit = useCallback(() => {
     const now = Date.now();
@@ -183,30 +193,25 @@ export function useAlienVisit({ plantedMelonCount, todayKey, mutationDoctorSigna
     ];
     const idSuffix = Math.random().toString(36).slice(2, 8);
     const appearance = createAppearance(candidate.type, candidate.messageKey, now, idSuffix);
-    let success = false;
 
-    setAlienVisit((prev) => {
+    const next = applyAlienVisitUpdate((prev) => {
       const cleanedVisit = clearExpiredAppearance(prev, now);
 
       if (cleanedVisit.current && cleanedVisit.current.expiresAt > now) {
-        activeAlienExpiresAtRef.current = cleanedVisit.current.expiresAt;
         return cleanedVisit;
       }
 
-      activeAlienExpiresAtRef.current = appearance.expiresAt;
-      success = true;
       return {
         ...cleanedVisit,
         current: appearance,
       };
     });
 
-    return success;
-  }, [setAlienVisit]);
+    return next.current?.id === appearance.id;
+  }, [applyAlienVisitUpdate]);
 
   return {
     alienVisit,
-    setAlienVisit,
     summonDriftBottleVisit,
   };
 }

--- a/src/hooks/useAlienVisit.ts
+++ b/src/hooks/useAlienVisit.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useLocalStorage } from './useLocalStorage';
 import type {
   AlienAppearance,
@@ -10,6 +10,13 @@ import { DEFAULT_ALIEN_VISIT } from '../types/farm';
 
 const ALIEN_VISIT_STORAGE_KEY = 'alienVisit';
 const ALIEN_DISPLAY_DURATION_MS = 3_000;
+const DRIFT_BOTTLE_SUMMON_CANDIDATES: readonly {
+  type: AlienType;
+  messageKey: AlienDialogueKey;
+}[] = [
+  { type: 'melon-alien', messageKey: 'alienMelonGreeting' },
+  { type: 'mutation-doctor', messageKey: 'alienMutationDoctor' },
+];
 
 interface UseAlienVisitOptions {
   plantedMelonCount: number;
@@ -89,6 +96,11 @@ export function useAlienVisit({ plantedMelonCount, todayKey, mutationDoctorSigna
   );
   const previousSignalRef = useRef(mutationDoctorSignal);
   const currentAlienExpiresAt = alienVisit.current?.expiresAt;
+  const activeAlienExpiresAtRef = useRef(currentAlienExpiresAt ?? 0);
+
+  useEffect(() => {
+    activeAlienExpiresAtRef.current = currentAlienExpiresAt ?? 0;
+  }, [currentAlienExpiresAt]);
 
   // App open / day check: melon alien appears with 10% chance when 3+ melons exist.
   useEffect(() => {
@@ -160,8 +172,36 @@ export function useAlienVisit({ plantedMelonCount, todayKey, mutationDoctorSigna
     };
   }, [currentAlienExpiresAt, setAlienVisit]);
 
+  const summonDriftBottleVisit = useCallback(() => {
+    const now = Date.now();
+    if (activeAlienExpiresAtRef.current > now) {
+      return false;
+    }
+
+    const cleanedVisit = clearExpiredAppearance(alienVisit, now);
+
+    if (cleanedVisit.current && cleanedVisit.current.expiresAt > now) {
+      activeAlienExpiresAtRef.current = cleanedVisit.current.expiresAt;
+      return false;
+    }
+
+    const candidate = DRIFT_BOTTLE_SUMMON_CANDIDATES[
+      Math.floor(Math.random() * DRIFT_BOTTLE_SUMMON_CANDIDATES.length)
+    ];
+    const idSuffix = Math.random().toString(36).slice(2, 8);
+    const appearance = createAppearance(candidate.type, candidate.messageKey, now, idSuffix);
+    activeAlienExpiresAtRef.current = appearance.expiresAt;
+
+    setAlienVisit({
+      ...cleanedVisit,
+      current: appearance,
+    });
+    return true;
+  }, [alienVisit, setAlienVisit]);
+
   return {
     alienVisit,
     setAlienVisit,
+    summonDriftBottleVisit,
   };
 }


### PR DESCRIPTION
## Summary
- only consume `drift-bottle` after `summonDriftBottleVisit()` succeeds
- stop relying on `consumeShopItem()`'s synchronous boolean return in the summon entry path
- preserve existing active-visit disabled/no-op behavior without refund juggling

## Proof
- forced `melon-alien` summon: `alienVisit.current.type=melon-alien`, overlay visible, `drift-bottle 3 -> 2`, chip disabled
- forced `mutation-doctor` summon: `alienVisit.current.type=mutation-doctor`, overlay visible, `drift-bottle 3 -> 2`, chip disabled
- existing active visit: chip stays disabled, overlay type unchanged, `drift-bottle` stays `3`
- expired visit: chip re-enables, re-summon succeeds, `drift-bottle 3 -> 2`

## Validation
- `npm run lint`
- `npm run build`
- `git diff --check`

Closes #72