### PR TITLE
fix: restore drift bottle summon path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1006,14 +1006,14 @@ function App() {
   }, [farm.guardianBarrierDate, farm.plots, shed.items, todayKey, consumeShopItem, activateGuardianBarrier, enqueueRecoveryToast, t]);
 
   const handleUseDriftBottle = useCallback(() => {
-    const consumed = consumeShopItem('drift-bottle');
-    if (!consumed) return;
+    const driftBottleCount = (shed.items as Record<string, number>)['drift-bottle'] ?? 0;
+    if (driftBottleCount <= 0) return;
 
     const summoned = summonDriftBottleVisit();
-    if (!summoned) {
-      addShedItem('drift-bottle', 1);
-    }
-  }, [consumeShopItem, summonDriftBottleVisit, addShedItem]);
+    if (!summoned) return;
+
+    consumeShopItem('drift-bottle');
+  }, [shed.items, summonDriftBottleVisit, consumeShopItem]);
 
   const handleUseTrapNet = useCallback((plotId: number) => {
     const targetPlot = farm.plots.find((p) => p.id === plotId);


### PR DESCRIPTION
## Summary
- re-cut the hotfix from latest `main` to remove the PR #79 base conflict
- keep only the required `src/App.tsx` delta in `handleUseDriftBottle()`
- only consume `drift-bottle` after `summonDriftBottleVisit()` succeeds

## Proof
- forced `melon-alien`: `alienVisit.current.type=melon-alien`, overlay visible, `drift-bottle 3 -> 2`, chip disabled
- forced `mutation-doctor`: `alienVisit.current.type=mutation-doctor`, overlay visible, `drift-bottle 3 -> 2`, chip disabled
- existing active visit: chip stays disabled, visit id unchanged, `drift-bottle` stays `3`
- expired visit: chip re-enables, re-summon succeeds, `drift-bottle 3 -> 2`

## Validation
- `npm run lint`
- `npm run build`
- `git diff --check`

Supersedes #79

Closes #72