### PR TITLE
feat: add trap-net thief rewards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,6 +82,7 @@ import {
   witherPlots,
 } from './farm/growth';
 import { getUnlockedSeedPoolGalaxies, getCollectedHybridVarietyCount } from './farm/galaxy';
+import { rollTrapNetThiefRewardItemId } from './farm/trapNetRewards';
 import {
   FARM_MILESTONE_DEFINITIONS,
   getAchievedFarmMilestoneIds,
@@ -251,6 +252,7 @@ function App() {
     activateSupernovaBottle,
     addPlotTracker,
     addStolenRecord,
+    settleCaughtThief,
     markStolenRecordRecovered,
     revivePlot,
     upgradePlotRarity,
@@ -1022,17 +1024,16 @@ function App() {
     const consumed = consumeShopItem('trap-net');
     if (!consumed) return;
 
-    setFarm((prev) => ({
-      ...prev,
-      plots: prev.plots.map((p) => (
-        p.id === plotId
-          ? { ...p, thief: undefined }
-          : p
-      )),
-    }));
-    addCoins(100);
+    const settled = settleCaughtThief(plotId);
+    if (!settled) {
+      addShedItem('trap-net', 1);
+      return;
+    }
+
+    addSeeds(2, 'epic');
+    addShedItem(rollTrapNetThiefRewardItemId(), 1);
     enqueueRecoveryToast(t.thiefCaught);
-  }, [farm.plots, consumeShopItem, setFarm, addCoins, enqueueRecoveryToast, t]);
+  }, [farm.plots, consumeShopItem, settleCaughtThief, addShedItem, addSeeds, enqueueRecoveryToast, t]);
 
   // ─── Gene injection handler ───
   const handleGeneInject = useCallback((galaxyId: import('./types/farm').GalaxyId, quality: import('./types/slicing').SeedQuality) => {

--- a/src/farm/trapNetRewards.ts
+++ b/src/farm/trapNetRewards.ts
@@ -1,0 +1,124 @@
+import type { FarmStorage, Plot, StolenRecord, ThiefStatus } from '../types/farm';
+import type { ShopItemId } from '../types/market';
+import type { ShedStorage } from '../types/slicing';
+
+export const CAUGHT_THIEF_SETTLEMENT_PREFIX = 'caught-thief';
+
+export const TRAP_NET_THIEF_REWARD_ITEM_POOL = [
+  'star-dew',
+  'trap-net',
+  'lullaby',
+  'crystal-ball',
+  'guardian-barrier',
+  'mutation-gun',
+  'moon-dew',
+  'drift-bottle',
+  'gene-modifier',
+  'supernova-bottle',
+  'star-tracker',
+  'nectar',
+] as const satisfies ReadonlyArray<Exclude<ShopItemId, 'mystery-seed' | 'premium-seed'>>;
+
+export type TrapNetThiefRewardItemId = typeof TRAP_NET_THIEF_REWARD_ITEM_POOL[number];
+
+export function rollTrapNetThiefRewardItemId(random: () => number = Math.random): TrapNetThiefRewardItemId {
+  const index = Math.floor(random() * TRAP_NET_THIEF_REWARD_ITEM_POOL.length);
+  return TRAP_NET_THIEF_REWARD_ITEM_POOL[index] ?? TRAP_NET_THIEF_REWARD_ITEM_POOL[0];
+}
+
+export function applyTrapNetCaughtThiefReward(
+  shed: ShedStorage,
+  itemId: TrapNetThiefRewardItemId,
+): ShedStorage {
+  const items = shed.items as Record<string, number>;
+  return {
+    ...shed,
+    seeds: {
+      ...shed.seeds,
+      epic: shed.seeds.epic + 2,
+    },
+    items: {
+      ...items,
+      [itemId]: (items[itemId] ?? 0) + 1,
+    } as ShedStorage['items'],
+  };
+}
+
+export function getCaughtThiefSettlementId(plotId: number, thief: ThiefStatus): string {
+  return [
+    CAUGHT_THIEF_SETTLEMENT_PREFIX,
+    plotId,
+    Math.floor(thief.appearedAt),
+    Math.floor(thief.stealsAt),
+  ].join(':');
+}
+
+export function clearPersistedCaughtThieves(plots: Plot[], stolenRecords: StolenRecord[]): Plot[] {
+  const settledIds = new Set(
+    stolenRecords
+      .filter((record) => record.id.startsWith(`${CAUGHT_THIEF_SETTLEMENT_PREFIX}:`))
+      .map((record) => record.id),
+  );
+
+  if (settledIds.size === 0) return plots;
+
+  return plots.map((plot) => {
+    if (!plot.thief) return plot;
+    const settlementId = getCaughtThiefSettlementId(plot.id, plot.thief);
+    return settledIds.has(settlementId)
+      ? { ...plot, thief: undefined }
+      : plot;
+  });
+}
+
+export function settleCaughtThiefSnapshot(
+  farm: FarmStorage,
+  plotId: number,
+  settledAt: number = Date.now(),
+): { nextFarm: FarmStorage; settled: boolean } {
+  const plot = farm.plots.find((item) => item.id === plotId);
+  if (!plot?.thief || !plot.varietyId) {
+    return {
+      nextFarm: farm,
+      settled: false,
+    };
+  }
+
+  const settlementId = getCaughtThiefSettlementId(plot.id, plot.thief);
+  const settlementExists = farm.stolenRecords.some((record) => record.id === settlementId);
+  const nextPlots = farm.plots.map((item) => {
+    if (item.id !== plotId || !item.thief) return item;
+    return getCaughtThiefSettlementId(item.id, item.thief) === settlementId
+      ? { ...item, thief: undefined }
+      : item;
+  });
+
+  if (settlementExists) {
+    return {
+      nextFarm: nextPlots.some((item, index) => item !== farm.plots[index])
+        ? { ...farm, plots: nextPlots }
+        : farm,
+      settled: false,
+    };
+  }
+
+  return {
+    nextFarm: {
+      ...farm,
+      plots: nextPlots,
+      stolenRecords: [
+        ...farm.stolenRecords,
+        {
+          id: settlementId,
+          plotId: plot.id,
+          varietyId: plot.varietyId,
+          stolenAt: Math.max(plot.thief.appearedAt, Math.min(settledAt, plot.thief.stealsAt)),
+          resolved: true,
+          recoveredCount: 0,
+          recoveredAt: settledAt,
+        },
+      ],
+    },
+    settled: true,
+  };
+}

--- a/src/hooks/useFarmStorage.ts
+++ b/src/hooks/useFarmStorage.ts
@@ -28,6 +28,7 @@ import {
 } from '../types/farm';
 import { DEFAULT_SEED_COUNTS } from '../types/slicing';
 import { getPlotCount } from '../farm/galaxy';
+import { clearPersistedCaughtThieves, settleCaughtThiefSnapshot } from '../farm/trapNetRewards';
 import {
   isLullabyGrowthBoostActive,
   isSupernovaBottleGrowthBoostActive,
@@ -508,6 +509,8 @@ function migrateFarm(raw: unknown): FarmStorage {
       .filter((record): record is StolenRecord => record !== null);
   }
 
+  result.plots = clearPersistedCaughtThieves(result.plots, result.stolenRecords);
+
   return result;
 }
 
@@ -518,6 +521,16 @@ export function useFarmStorage() {
   useEffect(() => {
     farmRef.current = farm;
   }, [farm]);
+
+  const commitFarm = useCallback((nextFarm: FarmStorage) => {
+    farmRef.current = nextFarm;
+    setFarm(nextFarm);
+    try {
+      localStorage.setItem(FARM_KEY, JSON.stringify(nextFarm));
+    } catch {
+      // Storage unavailable — ignore immediate persistence.
+    }
+  }, [setFarm]);
 
   useEffect(() => {
     const targetUnlockedPlotCount = resolveUnlockedPlotCount(
@@ -838,6 +851,14 @@ export function useFarmStorage() {
     }));
   }, [setFarm]);
 
+  const settleCaughtThief = useCallback((plotId: number): boolean => {
+    const { nextFarm, settled } = settleCaughtThiefSnapshot(farmRef.current, plotId);
+    if (nextFarm !== farmRef.current) {
+      commitFarm(nextFarm);
+    }
+    return settled;
+  }, [commitFarm]);
+
   /** 标记被偷记录为已追回（按 stolenAt 定位） */
   const markStolenRecordRecovered = useCallback((stolenAt: number): boolean => {
     if (!Number.isFinite(stolenAt) || stolenAt <= 0) return false;
@@ -961,6 +982,7 @@ export function useFarmStorage() {
     activateSupernovaBottle,
     addPlotTracker,
     addStolenRecord,
+    settleCaughtThief,
     markStolenRecordRecovered,
     revivePlot,
     upgradePlotRarity,

--- a/src/hooks/useShedStorage.ts
+++ b/src/hooks/useShedStorage.ts
@@ -158,29 +158,44 @@ function migrateShed(raw: unknown): ShedStorage {
 
 export function useShedStorage() {
   const [shed, setShed] = useLocalStorage<ShedStorage>(SHED_KEY, DEFAULT_SHED_STORAGE, migrateShed);
+  const shedRef = useRef(shed);
   const consumePrismaticSeedMutexRef = useRef(false);
   const consumePrismaticSeedResultRef = useRef(false);
   const consumeDarkMatterSeedMutexRef = useRef(false);
   const consumeDarkMatterSeedResultRef = useRef(false);
 
-  const addSeeds = useCallback((count: number, quality: SeedQuality = 'normal') => {
-    setShed(prev => ({
-      ...prev,
-      seeds: { ...prev.seeds, [quality]: prev.seeds[quality] + count },
-    }));
+  shedRef.current = shed;
+
+  const commitShed = useCallback((nextShed: ShedStorage) => {
+    shedRef.current = nextShed;
+    setShed(nextShed);
+    try {
+      localStorage.setItem(SHED_KEY, JSON.stringify(nextShed));
+    } catch {
+      // Storage unavailable — ignore immediate persistence.
+    }
   }, [setShed]);
+
+  const addSeeds = useCallback((count: number, quality: SeedQuality = 'normal') => {
+    const nextShed: ShedStorage = {
+      ...shedRef.current,
+      seeds: {
+        ...shedRef.current.seeds,
+        [quality]: shedRef.current.seeds[quality] + count,
+      },
+    };
+    commitShed(nextShed);
+  }, [commitShed]);
 
   const addItem = useCallback((itemId: string, count: number = 1) => {
     if (count <= 0) return;
-    setShed(prev => {
-      const nextItems = prev.items as Record<string, number>;
-      const current = nextItems[itemId] ?? 0;
-      return {
-        ...prev,
-        items: { ...nextItems, [itemId]: current + count } as ShedStorage['items'],
-      };
+    const nextItems = shedRef.current.items as Record<string, number>;
+    const current = nextItems[itemId] ?? 0;
+    commitShed({
+      ...shedRef.current,
+      items: { ...nextItems, [itemId]: current + count } as ShedStorage['items'],
     });
-  }, [setShed]);
+  }, [commitShed]);
 
   const incrementSliced = useCallback(() => {
     setShed(prev => ({ ...prev, totalSliced: prev.totalSliced + 1 }));
@@ -373,18 +388,15 @@ export function useShedStorage() {
 
   /** 消耗一个商城道具（返回是否成功） */
   const consumeShopItem = useCallback((itemId: string): boolean => {
-    let success = false;
-    setShed(prev => {
-      const items = prev.items as Record<string, number>;
-      if ((items[itemId] ?? 0) <= 0) return prev;
-      success = true;
-      return {
-        ...prev,
-        items: { ...items, [itemId]: items[itemId] - 1 } as ShedStorage['items'],
-      };
+    const items = shedRef.current.items as Record<string, number>;
+    if ((items[itemId] ?? 0) <= 0) return false;
+
+    commitShed({
+      ...shedRef.current,
+      items: { ...items, [itemId]: items[itemId] - 1 } as ShedStorage['items'],
     });
-    return success;
-  }, [setShed]);
+    return true;
+  }, [commitShed]);
 
   return {
     shed,


### PR DESCRIPTION
## Summary
- replace the old trap-net thief coin payout with `+2 epic seeds` and `+1` uniform random item from the locked 12-item pool
- persist one-shot settlement per thief instance so repeat tap / reload re-entry cannot double-grant
- immediately persist the trap-net reward inventory writes to avoid losing reward state across local refresh windows

## Verification
- `npm run lint`
- `npm run build`
- `git diff --check`
- `node --experimental-strip-types --input-type=module` inline assertions for happy path / duplicate guard / illegal states / reward writes

## Notes
- I attempted Playwright proof for AC3/duplicate/illegal-state, but the current farm page crashes under headless browser automation in this environment before the trap-net assertions can execute. The implementation proof above covers the reward/guard logic directly, and the issue scope intentionally avoids broader farm UI automation cleanup.

Closes #81
