### PR TITLE
feat: close circus-tent loop

### DIFF
--- a/artifacts/issue-83/PROOF.md
+++ b/artifacts/issue-83/PROOF.md
@@ -52,7 +52,38 @@ Observed UI state after reload:
 - Farm chip still rendered as `Melon Circus Tent · +20% · Today`
 - Chip remained disabled
 
-### 3. Same-day repeat use is a no-op
+### 3. Barrier-first path still allows circus-tent to grant `+20%`
+Setup before click, with same-day protection already present from `guardian-barrier` but `circus-tent` not yet activated:
+
+```json
+{
+  "guardianBarrierDate": "2026-04-10",
+  "circusTentActivatedAt": 0,
+  "circusTentCount": 1,
+  "buttonDisabled": false,
+  "buttonText": "Melon Circus Tent · 1"
+}
+```
+
+After clicking the Farm chip and waiting for the write to settle:
+
+```json
+{
+  "beforeBarrierDate": "2026-04-10",
+  "beforeActivatedAt": 0,
+  "beforeCount": 1,
+  "afterBarrierDate": "2026-04-10",
+  "afterActivatedAt": 1775787939648,
+  "afterCount": 0
+}
+```
+
+Observed UI state after the click:
+- Farm chip switched to `Melon Circus Tent · +20% · Today`
+- Chip became disabled after the first successful `circus-tent` activation
+- The pre-existing same-day barrier stayed intact while `circusTentActivatedAt` moved from `0` to a real timestamp, proving this path still gains the buff instead of being short-circuited by `guardianBarrierDate`
+
+### 4. Same-day repeat use is a no-op
 Attempted a second activation on the same day by clicking the disabled Farm chip again:
 
 ```json
@@ -69,7 +100,7 @@ Attempted a second activation on the same day by clicking the disabled Farm chip
 
 This confirms the repeat action does not re-activate, does not move the bonus start timestamp, and does not deduct inventory again.
 
-### 4. Cross-day persisted state expires automatically
+### 5. Cross-day persisted state expires automatically
 Simulated next-day persisted storage by writing yesterday's `guardianBarrierDate` and `circusTentActivatedAt`, then forcing a full reload:
 
 ```json

--- a/artifacts/issue-83/PROOF.md
+++ b/artifacts/issue-83/PROOF.md
@@ -1,0 +1,98 @@
+# Issue #83 Proof
+
+## Validation
+- `npm run build`
+- `npm run lint`
+
+Both commands passed locally on `feature/issue-83-circus-tent-loop`.
+
+## Manual proof log
+
+### 1. First activation clears thief and enables same-day protection + growth bonus
+Setup before click (localStorage on `http://127.0.0.1:4173/`):
+
+```json
+{
+  "guardianBarrierDate": "",
+  "circusTentActivatedAt": 0,
+  "thiefPresent": true,
+  "circusTentCount": 2
+}
+```
+
+After clicking the Farm chip `Melon Circus Tent · 2`:
+
+```json
+{
+  "guardianBarrierDate": "2026-04-10",
+  "circusTentActivatedAt": 1775780726334,
+  "thiefPresent": false,
+  "circusTentCount": 1
+}
+```
+
+Observed UI state after the click:
+- Farm chip changed to `Melon Circus Tent · +20% · Today`
+- Existing guardian barrier chip also became active because the protection truth source is still `guardianBarrierDate`
+- The active circus-tent chip was disabled, preventing same-day re-trigger
+
+### 2. Reload keeps the active state and persisted effect
+After a full page reload and reopening Farm:
+
+```json
+{
+  "guardianBarrierDate": "2026-04-10",
+  "circusTentActivatedAt": 1775780726334,
+  "thiefPresent": false,
+  "circusTentCount": 1
+}
+```
+
+Observed UI state after reload:
+- Farm chip still rendered as `Melon Circus Tent · +20% · Today`
+- Chip remained disabled
+
+### 3. Same-day repeat use is a no-op
+Attempted a second activation on the same day by clicking the disabled Farm chip again:
+
+```json
+{
+  "buttonDisabled": true,
+  "beforeActivatedAt": 1775780726334,
+  "afterActivatedAt": 1775780726334,
+  "beforeBarrierDate": "2026-04-10",
+  "afterBarrierDate": "2026-04-10",
+  "beforeCount": 1,
+  "afterCount": 1
+}
+```
+
+This confirms the repeat action does not re-activate, does not move the bonus start timestamp, and does not deduct inventory again.
+
+### 4. Cross-day persisted state expires automatically
+Simulated next-day persisted storage by writing yesterday's `guardianBarrierDate` and `circusTentActivatedAt`, then forcing a full reload:
+
+```json
+{
+  "guardianBarrierDate": "2026-04-09",
+  "circusTentActivatedAt": 1775694484178,
+  "thiefPresent": true,
+  "circusTentCount": 1,
+  "buttonDisabled": false,
+  "buttonText": "Melon Circus Tent · 1"
+}
+```
+
+Observed UI state after the reload:
+- The active `+20% · Today` state disappeared
+- The chip returned to its normal inventory label `Melon Circus Tent · 1`
+- The chip was enabled again
+- A thief remained present, showing the expired prior-day protection no longer auto-clears or blocks the current-day thief state
+
+## Implementation note for additive bonus behavior
+`circus-tent` now feeds the existing `calculateFarmGrowthBonusMinutes()` path. The function sums weighted overlap from:
+- circus-tent: `0.20`
+- lullaby: `0.30`
+- supernova bottle: `0.50`
+
+That keeps the three buffs additive in one existing bonus bucket instead of creating a separate multiplier path.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -248,6 +248,7 @@ function App() {
     buyPlot,
     updateActiveDate,
     activateGuardianBarrier,
+    activateCircusTent,
     activateLullaby,
     activateSupernovaBottle,
     addPlotTracker,
@@ -532,6 +533,7 @@ function App() {
       safeGrowthMinutes,
       safeStartTimestamp,
       safeEndTimestamp,
+      farm.circusTentActivatedAt,
       farm.lullabyActivatedAt,
       farm.supernovaBottleActivatedAt,
     );
@@ -539,7 +541,7 @@ function App() {
     const appliedGrowthMinutes = Math.max(0, Math.floor(rawGrowthMinutes));
     growthBoostCarryMinutesRef.current = rawGrowthMinutes - appliedGrowthMinutes;
     return appliedGrowthMinutes;
-  }, [farm.lullabyActivatedAt, farm.supernovaBottleActivatedAt]);
+  }, [farm.circusTentActivatedAt, farm.lullabyActivatedAt, farm.supernovaBottleActivatedAt]);
 
   const runFarmGrowth = useCallback((
     plots: Plot[],
@@ -996,7 +998,7 @@ function App() {
   const handleUseGuardianBarrier = useCallback(() => {
     const isAlreadyActive = farm.guardianBarrierDate === todayKey;
     const hasThiefToScare = farm.plots.some((p) => p.thief);
-    
+
     if (isAlreadyActive && !hasThiefToScare) return;
 
     const barrierCount = (shed.items as Record<string, number>)['guardian-barrier'] ?? 0;
@@ -1006,6 +1008,25 @@ function App() {
     consumeShopItem('guardian-barrier');
     enqueueRecoveryToast(t.itemGuardianBarrierActive);
   }, [farm.guardianBarrierDate, farm.plots, shed.items, todayKey, consumeShopItem, activateGuardianBarrier, enqueueRecoveryToast, t]);
+
+  const handleUseCircusTent = useCallback(() => {
+    if (farm.guardianBarrierDate === todayKey) return;
+
+    const nowTimestamp = Date.now();
+    const circusTentCount = (shed.items as Record<string, number>)['circus-tent'] ?? 0;
+    if (circusTentCount <= 0) return;
+
+    const consumed = consumeShopItem('circus-tent');
+    if (!consumed) return;
+
+    const activated = activateCircusTent(todayKey, nowTimestamp);
+    if (!activated) {
+      addShedItem('circus-tent', 1);
+      return;
+    }
+
+    enqueueRecoveryToast(`🎪 ${t.itemName('circus-tent')} · +20% · ${t.today}`);
+  }, [farm.guardianBarrierDate, todayKey, shed.items, consumeShopItem, activateCircusTent, addShedItem, enqueueRecoveryToast, t]);
 
   const handleUseDriftBottle = useCallback(() => {
     const driftBottleCount = (shed.items as Record<string, number>)['drift-bottle'] ?? 0;
@@ -2109,6 +2130,7 @@ function App() {
             onUseNectar={handleUseNectar}
             onUseStarTracker={handleUseStarTracker}
             onUseGuardianBarrier={handleUseGuardianBarrier}
+            onUseCircusTent={handleUseCircusTent}
             onUseDriftBottle={handleUseDriftBottle}
             onUseTrapNet={handleUseTrapNet}
             onInject={handleGeneInject}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,7 @@ import {
   calculateOfflineGrowth,
   calculateFocusBoost,
   getWitherStatus,
+  isCircusTentGrowthBoostActive,
   isLullabyGrowthBoostActive,
   isSupernovaBottleGrowthBoostActive,
   rollVariety,
@@ -1010,9 +1011,9 @@ function App() {
   }, [farm.guardianBarrierDate, farm.plots, shed.items, todayKey, consumeShopItem, activateGuardianBarrier, enqueueRecoveryToast, t]);
 
   const handleUseCircusTent = useCallback(() => {
-    if (farm.guardianBarrierDate === todayKey) return;
-
     const nowTimestamp = Date.now();
+    if (isCircusTentGrowthBoostActive(farm.circusTentActivatedAt, nowTimestamp)) return;
+
     const circusTentCount = (shed.items as Record<string, number>)['circus-tent'] ?? 0;
     if (circusTentCount <= 0) return;
 
@@ -1026,7 +1027,7 @@ function App() {
     }
 
     enqueueRecoveryToast(`🎪 ${t.itemName('circus-tent')} · +20% · ${t.today}`);
-  }, [farm.guardianBarrierDate, todayKey, shed.items, consumeShopItem, activateCircusTent, addShedItem, enqueueRecoveryToast, t]);
+  }, [farm.circusTentActivatedAt, shed.items, consumeShopItem, activateCircusTent, todayKey, addShedItem, enqueueRecoveryToast, t]);
 
   const handleUseDriftBottle = useCallback(() => {
     const driftBottleCount = (shed.items as Record<string, number>)['drift-bottle'] ?? 0;

--- a/src/components/FarmPage.tsx
+++ b/src/components/FarmPage.tsx
@@ -34,6 +34,7 @@ import { VARIETY_DEFS, RARITY_COLOR, RARITY_STARS } from '../types/farm';
 import {
   getGrowthStage,
   getSupernovaBottleGrowthBoostEndTimestamp,
+  isCircusTentGrowthBoostActive,
   isLullabyGrowthBoostActive,
   isSupernovaBottleGrowthBoostActive,
   isVarietyRevealed,
@@ -88,6 +89,7 @@ interface FarmPageProps {
   onUseNectar: (plotId: number) => void;
   onUseStarTracker: (plotId: number) => void;
   onUseGuardianBarrier: () => void;
+  onUseCircusTent: () => void;
   onUseDriftBottle: () => void;
   onUseTrapNet: (plotId: number) => void;
   onGoWarehouse: () => void;
@@ -182,6 +184,7 @@ export function FarmPage({
   onUseNectar,
   onUseStarTracker,
   onUseGuardianBarrier,
+  onUseCircusTent,
   onUseDriftBottle,
   onUseTrapNet,
   onGoWarehouse,
@@ -322,6 +325,7 @@ export function FarmPage({
   const nectarCount = (items as Record<string, number>)['nectar'] ?? 0;
   const starTrackerCount = (items as Record<string, number>)['star-tracker'] ?? 0;
   const guardianBarrierCount = (items as Record<string, number>)['guardian-barrier'] ?? 0;
+  const circusTentCount = (items as Record<string, number>)['circus-tent'] ?? 0;
   const driftBottleCount = (items as Record<string, number>)['drift-bottle'] ?? 0;
   const trapNetCount = (items as Record<string, number>)['trap-net'] ?? 0;
   const crystalBallCount = (items as Record<string, number>)['crystal-ball'] ?? 0;
@@ -329,6 +333,8 @@ export function FarmPage({
     ? t.varietyName(pendingRevealedNormalSeed.varietyId)
     : null;
   const canUseCrystalBall = crystalBallCount > 0 && !pendingRevealedNormalSeed && seeds.normal > 0;
+  const barrierActiveToday = farm.guardianBarrierDate === todayKey;
+  const circusTentActive = barrierActiveToday && isCircusTentGrowthBoostActive(farm.circusTentActivatedAt, nowTimestamp);
   const lullabyActive = isLullabyGrowthBoostActive(farm.lullabyActivatedAt, nowTimestamp);
   const supernovaBottleActive = isSupernovaBottleGrowthBoostActive(
     farm.supernovaBottleActivatedAt,
@@ -340,7 +346,6 @@ export function FarmPage({
         Math.ceil((getSupernovaBottleGrowthBoostEndTimestamp(farm.supernovaBottleActivatedAt) - nowTimestamp) / 60000),
       )
     : 0;
-  const barrierActiveToday = farm.guardianBarrierDate === todayKey;
   const canUseActivePlotStarDew = Boolean(activeGrowingPlot?.varietyId) && starDewCount > 0;
   const activeAlienSceneVisit = activeAlienVisit && activeAlienVisit.expiresAt > nowTimestamp
     ? activeAlienVisit
@@ -577,6 +582,33 @@ export function FarmPage({
               >
                 <span>🎪</span>
                 <span>{barrierActiveToday ? t.itemGuardianBarrierActive : `${t.itemName('guardian-barrier')} · ${guardianBarrierCount}`}</span>
+              </button>
+            )}
+            {(circusTentCount > 0 || circusTentActive) && (
+              <button
+                type="button"
+                onClick={onUseCircusTent}
+                disabled={circusTentActive}
+                data-testid="farm-circus-tent-chip"
+                data-active={circusTentActive ? 'true' : 'false'}
+                className="shrink-0 flex items-center gap-2 px-3 py-2 rounded-[var(--radius-sm)] border text-xs font-medium transition-all duration-200 ease-in-out hover:-translate-y-0.5 ui-hover-button disabled:hover:translate-y-0"
+                style={{
+                  background: circusTentActive
+                    ? 'linear-gradient(135deg, rgba(255,244,205,0.97) 0%, rgba(255,219,124,0.95) 100%)'
+                    : `${theme.surface}cc`,
+                  borderColor: circusTentActive ? '#f59e0b' : theme.border,
+                  color: circusTentActive ? '#92400e' : theme.text,
+                  boxShadow: 'var(--shadow-card)',
+                  cursor: circusTentActive ? 'default' : 'pointer',
+                }}
+                title={t.itemDescription('circus-tent')}
+              >
+                <span>🎪</span>
+                <span>
+                  {circusTentActive
+                    ? `${t.itemName('circus-tent')} · +20% · ${t.today}`
+                    : `${t.itemName('circus-tent')} · ${circusTentCount}`}
+                </span>
               </button>
             )}
             {driftBottleCount > 0 && (

--- a/src/farm/growth.ts
+++ b/src/farm/growth.ts
@@ -20,6 +20,7 @@ const THIEF_STEAL_DELAY_MINUTES = 30;
 const THIEF_STEAL_DELAY_MS = THIEF_STEAL_DELAY_MINUTES * 60 * 1000;
 const DAY_IN_MS = MINUTES_PER_DAY * 60 * 1000;
 
+export const CIRCUS_TENT_FARM_GROWTH_BONUS_RATE = 0.20;
 export const LULLABY_FARM_GROWTH_BONUS_RATE = 0.30;
 export const SUPERNOVA_BOTTLE_FARM_GROWTH_BONUS_RATE = 0.50;
 export const SUPERNOVA_BOTTLE_DURATION_MS = DAY_IN_MS;
@@ -37,6 +38,14 @@ function getTimeOverlapMs(
   windowEnd: number,
 ): number {
   return Math.max(0, Math.min(rangeEnd, windowEnd) - Math.max(rangeStart, windowStart));
+}
+
+function getCircusTentGrowthBoostWindow(activatedAt: number): { start: number; end: number } | null {
+  if (!Number.isFinite(activatedAt) || activatedAt <= 0) return null;
+  return {
+    start: activatedAt,
+    end: getLocalDayEndTimestamp(activatedAt),
+  };
 }
 
 function getLullabyGrowthBoostWindow(activatedAt: number): { start: number; end: number } | null {
@@ -57,6 +66,15 @@ function getSupernovaBottleGrowthBoostWindow(activatedAt: number): { start: numb
 
 export function getSupernovaBottleGrowthBoostEndTimestamp(activatedAt: number): number {
   return getSupernovaBottleGrowthBoostWindow(activatedAt)?.end ?? 0;
+}
+
+export function isCircusTentGrowthBoostActive(
+  activatedAt: number,
+  nowTimestamp: number = Date.now(),
+): boolean {
+  const window = getCircusTentGrowthBoostWindow(activatedAt);
+  if (!window) return false;
+  return nowTimestamp >= window.start && nowTimestamp < window.end;
 }
 
 export function isLullabyGrowthBoostActive(
@@ -81,6 +99,7 @@ export function calculateFarmGrowthBonusMinutes(
   baseGrowthMinutes: number,
   intervalStartTimestamp: number,
   intervalEndTimestamp: number,
+  circusTentActivatedAt: number,
   lullabyActivatedAt: number,
   supernovaBottleActivatedAt: number,
 ): number {
@@ -96,6 +115,12 @@ export function calculateFarmGrowthBonusMinutes(
     : fallbackStartTimestamp;
   const intervalDurationMs = Math.max(1, safeEndTimestamp - safeStartTimestamp);
 
+  const circusTentOverlapMs = (() => {
+    const window = getCircusTentGrowthBoostWindow(circusTentActivatedAt);
+    if (!window) return 0;
+    return getTimeOverlapMs(safeStartTimestamp, safeEndTimestamp, window.start, window.end);
+  })();
+
   const lullabyOverlapMs = (() => {
     const window = getLullabyGrowthBoostWindow(lullabyActivatedAt);
     if (!window) return 0;
@@ -108,7 +133,8 @@ export function calculateFarmGrowthBonusMinutes(
     return getTimeOverlapMs(safeStartTimestamp, safeEndTimestamp, window.start, window.end);
   })();
 
-  const weightedBonusRate = (lullabyOverlapMs / intervalDurationMs) * LULLABY_FARM_GROWTH_BONUS_RATE
+  const weightedBonusRate = (circusTentOverlapMs / intervalDurationMs) * CIRCUS_TENT_FARM_GROWTH_BONUS_RATE
+    + (lullabyOverlapMs / intervalDurationMs) * LULLABY_FARM_GROWTH_BONUS_RATE
     + (supernovaOverlapMs / intervalDurationMs) * SUPERNOVA_BOTTLE_FARM_GROWTH_BONUS_RATE;
 
   return safeBaseGrowthMinutes * weightedBonusRate;

--- a/src/hooks/useFarmStorage.ts
+++ b/src/hooks/useFarmStorage.ts
@@ -30,6 +30,7 @@ import { DEFAULT_SEED_COUNTS } from '../types/slicing';
 import { getPlotCount } from '../farm/galaxy';
 import { clearPersistedCaughtThieves, settleCaughtThiefSnapshot } from '../farm/trapNetRewards';
 import {
+  isCircusTentGrowthBoostActive,
   isLullabyGrowthBoostActive,
   isSupernovaBottleGrowthBoostActive,
   rollVariety,
@@ -805,11 +806,11 @@ export function useFarmStorage() {
     return true;
   }, [setFarm]);
 
-  /** 激活马戏团帐篷（active 复用 guardianBarrierDate，timestamp 只记录 bonus 起点） */
+  /** 激活马戏团帐篷（保护仍复用 guardianBarrierDate，只拦它自己当天重复激活） */
   const activateCircusTent = useCallback((todayKey: string, nowTimestamp: number = Date.now()): boolean => {
     if (!todayKey) return false;
     if (!Number.isFinite(nowTimestamp) || nowTimestamp <= 0) return false;
-    if (farmRef.current.guardianBarrierDate === todayKey) return false;
+    if (isCircusTentGrowthBoostActive(farmRef.current.circusTentActivatedAt, nowTimestamp)) return false;
 
     const nextFarm: FarmStorage = {
       ...farmRef.current,

--- a/src/hooks/useFarmStorage.ts
+++ b/src/hooks/useFarmStorage.ts
@@ -403,6 +403,7 @@ function migrateFarm(raw: unknown): FarmStorage {
     consecutiveInactiveDays: 0,
     lastActivityTimestamp: 0,
     guardianBarrierDate: '',
+    circusTentActivatedAt: 0,
     lullabyActivatedAt: 0,
     supernovaBottleActivatedAt: 0,
     stolenRecords: [],
@@ -497,6 +498,9 @@ function migrateFarm(raw: unknown): FarmStorage {
   if (typeof s.consecutiveInactiveDays === 'number') result.consecutiveInactiveDays = s.consecutiveInactiveDays;
   if (typeof s.lastActivityTimestamp === 'number') result.lastActivityTimestamp = s.lastActivityTimestamp;
   if (typeof s.guardianBarrierDate === 'string') result.guardianBarrierDate = s.guardianBarrierDate;
+  if (typeof s.circusTentActivatedAt === 'number' && Number.isFinite(s.circusTentActivatedAt)) {
+    result.circusTentActivatedAt = Math.max(0, s.circusTentActivatedAt);
+  }
   if (typeof s.lullabyActivatedAt === 'number' && Number.isFinite(s.lullabyActivatedAt)) {
     result.lullabyActivatedAt = Math.max(0, s.lullabyActivatedAt);
   }
@@ -801,6 +805,23 @@ export function useFarmStorage() {
     return true;
   }, [setFarm]);
 
+  /** 激活马戏团帐篷（active 复用 guardianBarrierDate，timestamp 只记录 bonus 起点） */
+  const activateCircusTent = useCallback((todayKey: string, nowTimestamp: number = Date.now()): boolean => {
+    if (!todayKey) return false;
+    if (!Number.isFinite(nowTimestamp) || nowTimestamp <= 0) return false;
+    if (farmRef.current.guardianBarrierDate === todayKey) return false;
+
+    const nextFarm: FarmStorage = {
+      ...farmRef.current,
+      guardianBarrierDate: todayKey,
+      circusTentActivatedAt: nowTimestamp,
+      plots: farmRef.current.plots.map((plot) => (plot.thief ? { ...plot, thief: undefined } : plot)),
+    };
+    farmRef.current = nextFarm;
+    setFarm(nextFarm);
+    return true;
+  }, [setFarm]);
+
   /** 激活原初摇篮曲（当天有效） */
   const activateLullaby = useCallback((nowTimestamp: number = Date.now()): boolean => {
     if (!Number.isFinite(nowTimestamp) || nowTimestamp <= 0) return false;
@@ -978,6 +999,7 @@ export function useFarmStorage() {
     buyPlot,
     updateActiveDate,
     activateGuardianBarrier,
+    activateCircusTent,
     activateLullaby,
     activateSupernovaBottle,
     addPlotTracker,

--- a/src/types/farm.ts
+++ b/src/types/farm.ts
@@ -749,6 +749,7 @@ export interface FarmStorage {
   consecutiveInactiveDays: number; // 连续未活跃天数（用于枯萎检测）
   lastActivityTimestamp: number; // 最近活跃时间戳（ms）
   guardianBarrierDate: string; // 守护结界生效日期 (YYYY-MM-DD)
+  circusTentActivatedAt: number; // 马戏团帐篷激活时间（ms，仅用于当天 +20% bonus 起点；active 仍以 guardianBarrierDate 为准）
   lullabyActivatedAt: number; // 原初摇篮曲激活时间（ms）
   supernovaBottleActivatedAt: number; // 超新星之瓶激活时间（ms）
   stolenRecords: StolenRecord[]; // 用于追回机制
@@ -789,6 +790,7 @@ export const DEFAULT_FARM_STORAGE: FarmStorage = {
   consecutiveInactiveDays: 0,
   lastActivityTimestamp: 0,
   guardianBarrierDate: '',
+  circusTentActivatedAt: 0,
   lullabyActivatedAt: 0,
   supernovaBottleActivatedAt: 0,
   stolenRecords: [],


### PR DESCRIPTION
## Summary
- wire `circus-tent` into the existing farm-wide growth bonus pipeline as a same-day `+20%` additive buff
- reuse `guardianBarrierDate` as the same-day active/no-op truth source while clearing any live thief immediately on first activation
- add Farm UI/proof coverage for first use, reload persistence, same-day no-op, and next-day expiry

## Testing
- npm run build
- npm run lint
- manual proof in `artifacts/issue-83/PROOF.md`

Closes #83
