### PR TITLE
fix: fold alien-flare into drift-bottle

### DIFF
--- a/artifacts/issue-90/PROOF.md
+++ b/artifacts/issue-90/PROOF.md
@@ -1,0 +1,36 @@
+# Issue #90 Proof
+
+## Legacy inventory normalization
+
+Source script: `artifacts/issue-90/proof-check.ts`
+Output snapshot: `artifacts/issue-90/proof-check.output.json`
+
+Verified with source-backed assertions:
+- legacy-only inventory: `alien-flare=2`, `drift-bottle=0` reloads into `drift-bottle=2`
+- mixed inventory: `alien-flare=2`, `drift-bottle=3` reloads into `drift-bottle=5`
+- current consumption path: consuming one `drift-bottle` from normalized stock succeeds and leaves `drift-bottle=4`
+- reload stability: re-running migration after consumption keeps `drift-bottle=4` and does not recreate `alien-flare`
+- redirected output path: the active common drop pool now contains `drift-bottle`, and active warehouse item ids no longer contain `alien-flare`
+
+## Interactive check
+
+Preview build verified in browser with `localStorage['watermelon-shed'] = { items: { 'alien-flare': 2, 'drift-bottle': 0 } }`:
+- first load into Farm shows `🍾 Interstellar Drift Bottle · 2`
+- using the existing Farm chip once decrements it to `🍾 Interstellar Drift Bottle · 1`
+- reload + returning to Farm still shows `🍾 Interstellar Drift Bottle · 1`
+
+## Validation
+
+Executed in `/home/ycz87/projects/cosmelonclock/.worktrees/issue-90`:
+
+```bash
+npm run lint
+npm run build
+git diff --check
+```
+
+Results:
+- `npm run lint` ✅
+- `npm run build` ✅
+- `git diff --check` ✅
+- existing Vite/Tailwind build warnings remain unchanged (`rounded-[var(--radius-*)]` CSS parse warning, large chunk warning)

--- a/artifacts/issue-90/proof-check.output.json
+++ b/artifacts/issue-90/proof-check.output.json
@@ -1,0 +1,25 @@
+{
+  "legacyOnlyDriftBottle": 2,
+  "mixedInventoryDriftBottle": 5,
+  "postConsumeDriftBottle": 4,
+  "reloadStableDriftBottle": 4,
+  "commonDropPool": [
+    "starlight-fertilizer",
+    "drift-bottle",
+    "thief-trap",
+    "star-telescope",
+    "circus-tent",
+    "lullaby-record"
+  ],
+  "activeWarehouseItemIds": [
+    "starlight-fertilizer",
+    "supernova-bottle",
+    "drift-bottle",
+    "thief-trap",
+    "star-telescope",
+    "moonlight-dew",
+    "circus-tent",
+    "gene-modifier",
+    "lullaby-record"
+  ]
+}

--- a/artifacts/issue-90/proof-check.ts
+++ b/artifacts/issue-90/proof-check.ts
@@ -1,0 +1,54 @@
+import { ALL_ITEM_IDS, COMMON_ITEMS } from '../../src/types/slicing.ts';
+import { consumeShopItemSnapshot, migrateShed } from '../../src/hooks/useShedStorage.ts';
+
+function getItemCount(items: Record<string, number>, itemId: string): number {
+  return items[itemId] ?? 0;
+}
+
+function assert(condition: unknown, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const legacyOnly = migrateShed({
+  items: {
+    'alien-flare': 2,
+    'drift-bottle': 0,
+  },
+});
+const legacyOnlyItems = legacyOnly.items as Record<string, number>;
+assert(getItemCount(legacyOnlyItems, 'drift-bottle') === 2, 'legacy-only inventory should normalize into drift-bottle');
+assert(getItemCount(legacyOnlyItems, 'alien-flare') === 0, 'legacy-only inventory should not keep alien-flare as active stock');
+
+const mixedInventory = migrateShed({
+  items: {
+    'alien-flare': 2,
+    'drift-bottle': 3,
+  },
+});
+const mixedItems = mixedInventory.items as Record<string, number>;
+assert(getItemCount(mixedItems, 'drift-bottle') === 5, 'mixed inventory should preserve total quantity');
+assert(getItemCount(mixedItems, 'alien-flare') === 0, 'mixed inventory should not double-track alien-flare');
+
+const consumedVisit = consumeShopItemSnapshot(mixedInventory, 'drift-bottle');
+assert(consumedVisit.consumed, 'migrated drift-bottle stock should be consumable through the current entry path');
+const consumedItems = consumedVisit.nextShed.items as Record<string, number>;
+assert(getItemCount(consumedItems, 'drift-bottle') === 4, 'drift-bottle consumption should decrement the normalized stock once');
+
+const reloadedInventory = migrateShed(consumedVisit.nextShed);
+const reloadedItems = reloadedInventory.items as Record<string, number>;
+assert(getItemCount(reloadedItems, 'drift-bottle') === 4, 'reload should keep the normalized total stable');
+assert(getItemCount(reloadedItems, 'alien-flare') === 0, 'reload should remain idempotent for legacy stock');
+
+assert(COMMON_ITEMS.includes('drift-bottle'), 'current common drop pool should include drift-bottle');
+assert(!ALL_ITEM_IDS.includes('alien-flare' as never), 'active warehouse item ids should no longer include alien-flare');
+
+console.log(JSON.stringify({
+  legacyOnlyDriftBottle: getItemCount(legacyOnlyItems, 'drift-bottle'),
+  mixedInventoryDriftBottle: getItemCount(mixedItems, 'drift-bottle'),
+  postConsumeDriftBottle: getItemCount(consumedItems, 'drift-bottle'),
+  reloadStableDriftBottle: getItemCount(reloadedItems, 'drift-bottle'),
+  commonDropPool: COMMON_ITEMS,
+  activeWarehouseItemIds: ALL_ITEM_IDS,
+}, null, 2));

--- a/src/hooks/useShedStorage.ts
+++ b/src/hooks/useShedStorage.ts
@@ -24,8 +24,16 @@ const INJECTED_SEED_QUALITIES: SeedQuality[] = ['normal', 'epic', 'legendary'];
 const INJECTED_SEED_GALAXIES: InjectedSeed['targetGalaxyId'][] = [
   'thick-earth', 'fire', 'water', 'wood', 'metal', 'rainbow', 'dark-matter',
 ];
+// Keep legacy shed item ids readable but store and consume them through the current product id.
+const LEGACY_SHED_ITEM_ALIASES = {
+  'alien-flare': 'drift-bottle',
+} as const;
 
-function migrateShed(raw: unknown): ShedStorage {
+export function normalizeShedItemId(itemId: string): string {
+  return LEGACY_SHED_ITEM_ALIASES[itemId as keyof typeof LEGACY_SHED_ITEM_ALIASES] ?? itemId;
+}
+
+export function migrateShed(raw: unknown): ShedStorage {
   if (!raw || typeof raw !== 'object') return DEFAULT_SHED_STORAGE;
   const s = raw as Record<string, unknown>;
   const result: ShedStorage = {
@@ -59,13 +67,14 @@ function migrateShed(raw: unknown): ShedStorage {
       if (typeof value !== 'number' || !Number.isFinite(value)) continue;
 
       const normalizedCount = Math.max(0, Math.floor(value));
-      const migratedSeedQuality = SHOP_SEED_ITEM_TO_QUALITY[id as keyof typeof SHOP_SEED_ITEM_TO_QUALITY];
+      const normalizedItemId = normalizeShedItemId(id);
+      const migratedSeedQuality = SHOP_SEED_ITEM_TO_QUALITY[normalizedItemId as keyof typeof SHOP_SEED_ITEM_TO_QUALITY];
       if (migratedSeedQuality) {
         result.seeds[migratedSeedQuality] += normalizedCount;
         continue;
       }
 
-      nextItems[id] = normalizedCount;
+      nextItems[normalizedItemId] = (nextItems[normalizedItemId] ?? 0) + normalizedCount;
     }
   }
 
@@ -156,6 +165,28 @@ function migrateShed(raw: unknown): ShedStorage {
   return result;
 }
 
+export function consumeShopItemSnapshot(
+  shed: ShedStorage,
+  itemId: string,
+): { nextShed: ShedStorage; consumed: boolean } {
+  const normalizedItemId = normalizeShedItemId(itemId);
+  const items = shed.items as Record<string, number>;
+  if ((items[normalizedItemId] ?? 0) <= 0) {
+    return { nextShed: shed, consumed: false };
+  }
+
+  return {
+    nextShed: {
+      ...shed,
+      items: {
+        ...items,
+        [normalizedItemId]: items[normalizedItemId] - 1,
+      } as ShedStorage['items'],
+    },
+    consumed: true,
+  };
+}
+
 export function useShedStorage() {
   const [shed, setShed] = useLocalStorage<ShedStorage>(SHED_KEY, DEFAULT_SHED_STORAGE, migrateShed);
   const shedRef = useRef(shed);
@@ -189,11 +220,12 @@ export function useShedStorage() {
 
   const addItem = useCallback((itemId: string, count: number = 1) => {
     if (count <= 0) return;
+    const normalizedItemId = normalizeShedItemId(itemId);
     const nextItems = shedRef.current.items as Record<string, number>;
-    const current = nextItems[itemId] ?? 0;
+    const current = nextItems[normalizedItemId] ?? 0;
     commitShed({
       ...shedRef.current,
-      items: { ...nextItems, [itemId]: current + count } as ShedStorage['items'],
+      items: { ...nextItems, [normalizedItemId]: current + count } as ShedStorage['items'],
     });
   }, [commitShed]);
 
@@ -388,13 +420,10 @@ export function useShedStorage() {
 
   /** 消耗一个商城道具（返回是否成功） */
   const consumeShopItem = useCallback((itemId: string): boolean => {
-    const items = shedRef.current.items as Record<string, number>;
-    if ((items[itemId] ?? 0) <= 0) return false;
+    const { nextShed, consumed } = consumeShopItemSnapshot(shedRef.current, itemId);
+    if (!consumed) return false;
 
-    commitShed({
-      ...shedRef.current,
-      items: { ...items, [itemId]: items[itemId] - 1 } as ShedStorage['items'],
-    });
+    commitShed(nextShed);
     return true;
   }, [commitShed]);
 

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -454,7 +454,7 @@ export const de: Messages = {
   sliceButton: '🔪 Schneiden',
   itemName: (id) => ({
     'starlight-fertilizer': '⚡ Sternenlicht-Dünger',
-    'alien-flare': '🛸 Alien-Signalrakete',
+    'alien-flare': 'Interstellare Flaschenpost',
     'thief-trap': '🪤 Diebfalle',
     'star-telescope': '🔮 Sternenteleskop',
     'moonlight-dew': '🌙 Mondlichttau',
@@ -485,6 +485,7 @@ export const de: Messages = {
     'crystal-ball': 'Propheten-Kristallkugel enthüllt 1 normales Mysteriensamen vor dem Pflanzen',
     'guardian-barrier': 'Schutzbarriere bewahrt das Feld vor Katastrophen',
     'mutation-gun': 'Mutationsstrahlenkanone löst magische Mutationen aus',
+    'alien-flare': 'Interstellare Treibflasche kann Überraschungen bringen',
     'drift-bottle': 'Interstellare Treibflasche kann Überraschungen bringen',
     'gene-modifier': 'Genmodifikator erschafft neue Hybrid-Sorten',
     'supernova-bottle': 'Supernova-Flasche setzt gewaltige Energie frei',
@@ -497,7 +498,8 @@ export const de: Messages = {
   itemFlavor: (id) => ({
     'starlight-fertilizer': 'Mysteriöser Dünger aus einer fernen Galaxie — riecht nach Sternenstaub',
     'supernova-bottle': 'Enthält die explosive Energie einer Mikro-Supernova',
-    'alien-flare': 'Rufe "Hier gibt es Melonen!" ins All und hoffe auf freundliche Besucher',
+    'alien-flare': 'Schicke eine Flaschenpost ins All und warte auf unerwarteten Besuch',
+    'drift-bottle': 'Schicke eine Flaschenpost ins All und warte auf unerwarteten Besuch',
     'thief-trap': 'Sieht aus wie eine normale Melone, ist aber ein Käfig',
     'star-telescope': 'Angeblich ein Relikt eines Alien-Observatoriums',
     'moonlight-dew': 'Geheimnisvolle Tautropfen, die nur bei Vollmond entstehen',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -454,7 +454,7 @@ export const en: Messages = {
   sliceButton: '🔪 Slice',
   itemName: (id) => ({
     'starlight-fertilizer': '⚡ Starlight Fertilizer',
-    'alien-flare': '🛸 Alien Flare',
+    'alien-flare': 'Interstellar Drift Bottle',
     'thief-trap': '🪤 Thief Trap',
     'star-telescope': '🔮 Star Telescope',
     'moonlight-dew': '🌙 Moonlight Dew',
@@ -485,6 +485,7 @@ export const en: Messages = {
     'crystal-ball': 'Prophet crystal ball, reveal 1 normal mystery seed before planting',
     'guardian-barrier': 'Guardian barrier, protect farm from disasters',
     'mutation-gun': 'Mutation ray gun, make crops mutate magically',
+    'alien-flare': 'Interstellar drift bottle, may bring surprises',
     'drift-bottle': 'Interstellar drift bottle, may bring surprises',
     'gene-modifier': 'Gene modifier, create new hybrid varieties',
     'supernova-bottle': 'Supernova bottle, release powerful energy',
@@ -497,7 +498,8 @@ export const en: Messages = {
   itemFlavor: (id) => ({
     'starlight-fertilizer': 'Mysterious fertilizer from a distant galaxy — smells like stardust',
     'supernova-bottle': 'Contains the explosive energy of a micro supernova',
-    'alien-flare': 'Shout "Melons here!" into the cosmos and hope for friendly visitors',
+    'alien-flare': 'Send a drift bottle into the cosmos and wait for an unexpected visitor',
+    'drift-bottle': 'Send a drift bottle into the cosmos and wait for an unexpected visitor',
     'thief-trap': 'Looks like an ordinary melon, but it\'s actually a cage',
     'star-telescope': 'Said to be a relic from an alien observatory',
     'moonlight-dew': 'Mysterious dewdrops that only form under a full moon',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -454,7 +454,7 @@ export const es: Messages = {
   sliceButton: '🔪 Cortar',
   itemName: (id) => ({
     'starlight-fertilizer': '⚡ Fertilizante estelar',
-    'alien-flare': '🛸 Bengala alienígena',
+    'alien-flare': 'Botella Interestelar',
     'thief-trap': '🪤 Trampa para ladrones',
     'star-telescope': '🔮 Telescopio estelar',
     'moonlight-dew': '🌙 Rocío lunar',
@@ -485,6 +485,7 @@ export const es: Messages = {
     'crystal-ball': 'Bola de cristal profética: revela 1 semilla misteriosa normal antes de plantar',
     'guardian-barrier': 'Barrera guardiana, protege la granja de desastres',
     'mutation-gun': 'Pistola de rayos mutantes, provoca mutaciones mágicas en los cultivos',
+    'alien-flare': 'Botella a la deriva interestelar, puede traer sorpresas',
     'drift-bottle': 'Botella a la deriva interestelar, puede traer sorpresas',
     'gene-modifier': 'Modificador genético, crea nuevas variedades híbridas',
     'supernova-bottle': 'Botella supernova, libera una energía poderosa',
@@ -497,7 +498,8 @@ export const es: Messages = {
   itemFlavor: (id) => ({
     'starlight-fertilizer': 'Fertilizante misterioso de una galaxia lejana — huele a polvo de estrellas',
     'supernova-bottle': 'Contiene la energía explosiva de una micro supernova',
-    'alien-flare': 'Grita "¡Aquí hay sandías!" al cosmos y reza por visitantes amigables',
+    'alien-flare': 'Lanza una botella a la deriva al cosmos y espera una visita inesperada',
+    'drift-bottle': 'Lanza una botella a la deriva al cosmos y espera una visita inesperada',
     'thief-trap': 'Parece una sandía normal, pero en realidad es una jaula',
     'star-telescope': 'Se dice que es una reliquia de un observatorio alienígena',
     'moonlight-dew': 'Gotas de rocío misteriosas que solo se forman con luna llena',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -454,7 +454,7 @@ export const fr: Messages = {
   sliceButton: '🔪 Couper',
   itemName: (id) => ({
     'starlight-fertilizer': '⚡ Engrais stellaire',
-    'alien-flare': '🛸 Fusée éclairante alien',
+    'alien-flare': 'Bouteille Interstellaire',
     'thief-trap': '🪤 Piège à voleur',
     'star-telescope': '🔮 Télescope stellaire',
     'moonlight-dew': '🌙 Rosée de lune',
@@ -485,6 +485,7 @@ export const fr: Messages = {
     'crystal-ball': 'Boule de cristal prophétique : révèle 1 graine mystère normale avant de planter',
     'guardian-barrier': 'Barrière gardienne, protège la ferme des catastrophes',
     'mutation-gun': 'Pistolet à rayon mutant, provoque des mutations magiques',
+    'alien-flare': 'Bouteille à la dérive interstellaire, peut apporter des surprises',
     'drift-bottle': 'Bouteille à la dérive interstellaire, peut apporter des surprises',
     'gene-modifier': 'Modificateur génétique, crée de nouvelles variétés hybrides',
     'supernova-bottle': 'Bouteille supernova, libère une énergie puissante',
@@ -497,7 +498,8 @@ export const fr: Messages = {
   itemFlavor: (id) => ({
     'starlight-fertilizer': 'Engrais mystérieux d\'une galaxie lointaine — sent la poussière d\'étoiles',
     'supernova-bottle': 'Contient l\'énergie explosive d\'une micro supernova',
-    'alien-flare': 'Criez "Il y a des pastèques ici !" dans le cosmos et priez',
+    'alien-flare': 'Lancez une bouteille à la dérive dans le cosmos et attendez une visite inattendue',
+    'drift-bottle': 'Lancez une bouteille à la dérive dans le cosmos et attendez une visite inattendue',
     'thief-trap': 'Ressemble à une pastèque ordinaire, mais c\'est en fait une cage',
     'star-telescope': 'Serait une relique d\'un observatoire alien',
     'moonlight-dew': 'Gouttes de rosée mystérieuses qui ne se forment qu\'à la pleine lune',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -454,7 +454,7 @@ export const ja: Messages = {
   sliceButton: '🔪 カット',
   itemName: (id) => ({
     'starlight-fertilizer': '⚡ スターライト肥料',
-    'alien-flare': '🛸 エイリアン信号弾',
+    'alien-flare': '星間漂流ボトル',
     'thief-trap': '🪤 泥棒トラップ',
     'star-telescope': '🔮 星間望遠鏡',
     'moonlight-dew': '🌙 月光の雫',
@@ -485,6 +485,7 @@ export const ja: Messages = {
     'crystal-ball': '予知水晶球。普通の神秘の種を植える前に 1 個だけ正体を明かす',
     'guardian-barrier': '守護結界で畑を災害から守る',
     'mutation-gun': '変異レイガンで作物に不思議な変異を起こす',
+    'alien-flare': '星間漂流ボトルが思わぬサプライズを運ぶかも',
     'drift-bottle': '星間漂流ボトルが思わぬサプライズを運ぶかも',
     'gene-modifier': '遺伝子改造器で新しい交配品種を作る',
     'supernova-bottle': 'スーパーノヴァボトルで強大なエネルギーを解放',
@@ -497,7 +498,8 @@ export const ja: Messages = {
   itemFlavor: (id) => ({
     'starlight-fertilizer': '遠い銀河からの神秘的な肥料、星の香りがする',
     'supernova-bottle': '超新星の爆発エネルギーが詰まっている',
-    'alien-flare': '宇宙に「ここにスイカがある！」と叫んで、良い人が来ることを祈る',
+    'alien-flare': '宇宙へ漂流ボトルを流して、思いがけない来訪者を待とう',
+    'drift-bottle': '宇宙へ漂流ボトルを流して、思いがけない来訪者を待とう',
     'thief-trap': '普通のスイカに見えるが、実は檻',
     'star-telescope': 'エイリアン天文台の遺物と言われている',
     'moonlight-dew': '満月の夜にだけ凝結する神秘的な露',

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -454,7 +454,7 @@ export const ko: Messages = {
   sliceButton: '🔪 자르기',
   itemName: (id) => ({
     'starlight-fertilizer': '⚡ 별빛 비료',
-    'alien-flare': '🛸 외계인 신호탄',
+    'alien-flare': '성간 표류병',
     'thief-trap': '🪤 도둑 함정',
     'star-telescope': '🔮 성간 망원경',
     'moonlight-dew': '🌙 달빛 이슬',
@@ -485,6 +485,7 @@ export const ko: Messages = {
     'crystal-ball': '예언 수정구로 일반 미스터리 씨앗 1개의 정체를 심기 전에 미리 밝힙니다',
     'guardian-barrier': '수호 결계로 농장을 재해로부터 보호',
     'mutation-gun': '변이 광선총으로 작물에 신비한 변이를 유도',
+    'alien-flare': '성간 표류 병이 뜻밖의 놀라움을 가져올 수도 있음',
     'drift-bottle': '성간 표류 병이 뜻밖의 놀라움을 가져올 수도 있음',
     'gene-modifier': '유전자 개조기로 새로운 교배 품종 창조',
     'supernova-bottle': '초신성 병으로 강력한 에너지 방출',
@@ -497,7 +498,8 @@ export const ko: Messages = {
   itemFlavor: (id) => ({
     'starlight-fertilizer': '먼 은하에서 온 신비한 비료, 별의 향기가 난다',
     'supernova-bottle': '초소형 초신성의 폭발 에너지가 담겨 있다',
-    'alien-flare': '우주를 향해 "여기 수박 있어요!"라고 외치고 좋은 사람이 오길 기도하자',
+    'alien-flare': '우주로 표류병을 띄워 보내고 뜻밖의 방문객을 기다리자',
+    'drift-bottle': '우주로 표류병을 띄워 보내고 뜻밖의 방문객을 기다리자',
     'thief-trap': '평범한 수박처럼 보이지만 사실은 우리',
     'star-telescope': '외계 천문대의 유물이라고 한다',
     'moonlight-dew': '보름달에만 맺히는 신비한 이슬',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -454,7 +454,7 @@ export const zh: Messages = {
   sliceButton: '🔪 切瓜',
   itemName: (id) => ({
     'starlight-fertilizer': '⚡ 星光肥料',
-    'alien-flare': '🛸 外星信号弹',
+    'alien-flare': '星际漂流瓶',
     'thief-trap': '🪤 瓜贼陷阱',
     'star-telescope': '🔮 星际望远镜',
     'moonlight-dew': '🌙 月光露水',
@@ -485,6 +485,7 @@ export const zh: Messages = {
     'crystal-ball': '预言水晶球，提前揭晓 1 颗普通神秘种子',
     'guardian-barrier': '守护结界，保护瓜田免受灾害',
     'mutation-gun': '变异射线枪，让作物产生神奇变异',
+    'alien-flare': '星际漂流瓶，可能带来意外惊喜',
     'drift-bottle': '星际漂流瓶，可能带来意外惊喜',
     'gene-modifier': '基因改造器，创造全新杂交品种',
     'supernova-bottle': '超新星瓶，释放强大能量',
@@ -497,7 +498,8 @@ export const zh: Messages = {
   itemFlavor: (id) => ({
     'starlight-fertilizer': '来自遥远星系的神秘肥料，闻起来像星星的味道',
     'supernova-bottle': '装着一颗微型超新星的爆发能量',
-    'alien-flare': '向宇宙喊一声"这里有瓜！"然后祈祷来的是好人',
+    'alien-flare': '把消息装进漂流瓶抛向宇宙，等一位意外访客顺流而来',
+    'drift-bottle': '把消息装进漂流瓶抛向宇宙，等一位意外访客顺流而来',
     'thief-trap': '看起来像个普通西瓜，其实是个笼子',
     'star-telescope': '据说是外星天文台的遗物',
     'moonlight-dew': '只在满月时凝结的神秘露珠',

--- a/src/i18n/locales/zhTW.ts
+++ b/src/i18n/locales/zhTW.ts
@@ -454,7 +454,7 @@ export const zhTW: Messages = {
   sliceButton: '🔪 切瓜',
   itemName: (id) => ({
     'starlight-fertilizer': '⚡ 星光肥料',
-    'alien-flare': '🛸 外星信號彈',
+    'alien-flare': '星際漂流瓶',
     'thief-trap': '🪤 瓜賊陷阱',
     'star-telescope': '🔮 星際望遠鏡',
     'moonlight-dew': '🌙 月光露水',
@@ -485,6 +485,7 @@ export const zhTW: Messages = {
     'crystal-ball': '預言水晶球，提前揭曉 1 顆普通神秘種子',
     'guardian-barrier': '守護結界，保護瓜田免受災害',
     'mutation-gun': '變異射線槍，讓作物產生神奇變異',
+    'alien-flare': '星際漂流瓶，可能帶來意外驚喜',
     'drift-bottle': '星際漂流瓶，可能帶來意外驚喜',
     'gene-modifier': '基因改造器，創造全新雜交品種',
     'supernova-bottle': '超新星瓶，釋放強大能量',
@@ -497,7 +498,8 @@ export const zhTW: Messages = {
   itemFlavor: (id) => ({
     'starlight-fertilizer': '來自遙遠星系的神祕肥料，聞起來像星星的味道',
     'supernova-bottle': '裝著一顆微型超新星的爆發能量',
-    'alien-flare': '向宇宙喊一聲「這裡有瓜！」然後祈禱來的是好人',
+    'alien-flare': '把訊息裝進漂流瓶拋向宇宙，等一位意外訪客順流而來',
+    'drift-bottle': '把訊息裝進漂流瓶拋向宇宙，等一位意外訪客順流而來',
     'thief-trap': '看起來像個普通西瓜，其實是個籠子',
     'star-telescope': '據說是外星天文臺的遺物',
     'moonlight-dew': '只在滿月時凝結的神祕露珠',

--- a/src/types/slicing.ts
+++ b/src/types/slicing.ts
@@ -7,7 +7,7 @@ import type { DarkMatterVarietyId, GalaxyId, HybridGalaxyPair, VarietyId } from 
 export type ItemId =
   | 'starlight-fertilizer'    // ⚡ 星光肥料（普通）
   | 'supernova-bottle'        // ☀️ 超新星能量瓶（稀有）
-  | 'alien-flare'             // 🛸 外星信号弹（普通）
+  | 'drift-bottle'            // 🍾 星际漂流瓶（普通）
   | 'thief-trap'              // 🪤 瓜贼陷阱（普通）
   | 'star-telescope'          // 🔮 星际望远镜（普通）
   | 'moonlight-dew'           // 🌙 月光露水（稀有）
@@ -26,7 +26,7 @@ export interface ItemDef {
 export const ITEM_DEFS: Record<ItemId, ItemDef> = {
   'starlight-fertilizer': { id: 'starlight-fertilizer', emoji: '⚡', rarity: 'common' },
   'supernova-bottle': { id: 'supernova-bottle', emoji: '☀️', rarity: 'rare' },
-  'alien-flare': { id: 'alien-flare', emoji: '🛸', rarity: 'common' },
+  'drift-bottle': { id: 'drift-bottle', emoji: '🍾', rarity: 'common' },
   'thief-trap': { id: 'thief-trap', emoji: '🪤', rarity: 'common' },
   'star-telescope': { id: 'star-telescope', emoji: '🔮', rarity: 'common' },
   'moonlight-dew': { id: 'moonlight-dew', emoji: '🌙', rarity: 'rare' },


### PR DESCRIPTION
## Summary
- fold legacy `alien-flare` stock into the active `drift-bottle` inventory during shed migration and future storage writes
- redirect current slicing/warehouse semantics to `drift-bottle` so users no longer keep a second active legacy item id
- add issue proof artifacts covering legacy-only stock, mixed stock, current consumption, reload stability, and active output ids

## Testing
- npm run lint
- npm run build
- git diff --check
- browser preview check with legacy `alien-flare` localStorage stock flowing through the existing Farm `drift-bottle` chip

## Proof
- artifacts/issue-90/PROOF.md
- artifacts/issue-90/proof-check.ts
- artifacts/issue-90/proof-check.output.json

Closes #90
