### PR TITLE
chore: bump version to 0.61.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pomodoro",
-  "version": "0.61.13",
+  "version": "0.61.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pomodoro",
-      "version": "0.61.13",
+      "version": "0.61.14",
       "dependencies": {
         "@capacitor/android": "^8.1.0",
         "@capacitor/cli": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pomodoro",
   "private": true,
-  "version": "0.61.13",
+  "version": "0.61.14",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- bump the app version from `0.61.13` to `0.61.14` in `package.json` and `package-lock.json`
- keep the already accepted `lullaby-record` compatibility implementation unchanged
- make the shipped version and cache-busting marker verifiable for the #92 release

## Testing
- npm run lint
- npm run build
- git diff --check
- Playwright check: app home screen renders `v0.61.14`

## Issue
- follow-up for #92 reject-impl (version bump only)
