### PR TITLE
docs: refresh README frontend hosting line

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@
 - [Tailwind CSS](https://tailwindcss.com/) 4
 - [Tauri](https://tauri.app/) 2.x — 桌面应用打包
 - [vite-plugin-pwa](https://vite-pwa-org.netlify.app/) — Service Worker + Web App Manifest
-- [Vercel](https://vercel.com/) — 部署
+- [Cloudflare Pages](https://pages.cloudflare.com/) — 部署
 - **后端：** Cloudflare Workers（Hono）— API + Auth 独立服务 + D1 数据库
 
 ## 本地运行


### PR DESCRIPTION
## Summary
- update the README tech-stack hosting line from the outdated Vercel wording to the current frontend hosting source of truth
- keep the change README-only and one-line scoped

## Testing
- verified `git diff --name-only origin/main...HEAD` only includes README.md

## Issue
- refs #103