### PR TITLE
fix: lock Settings auto-start toggles during active timer

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -60,6 +60,8 @@ function Toggle({ label, checked, onChange, disabled }: {
     <div className={`flex items-center justify-between gap-3 ${disabled ? 'opacity-40' : ''}`}>
       <div className="text-sm" style={{ color: t.textMuted }}>{label}</div>
       <button
+        type="button"
+        disabled={disabled}
         onClick={() => !disabled && onChange(!checked)}
         className={`relative w-10 h-5.5 rounded-full transition-colors duration-200 ease-in-out ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}
         style={{ backgroundColor: checked ? TOGGLE_GREEN : t.inputBg }}
@@ -200,6 +202,9 @@ export function Settings({ settings, onChange, disabled, isWorkRunning, onExport
   };
 
   const ambienceSummary = getActiveSoundsSummary(settings.ambienceMixer, i18n.ambienceNames);
+  const autoStartWorkDisabled = disabled;
+  const autoStartBreakDisabled = disabled || settings.workMinutes > 25;
+
   const handleVersionClick = () => {
     const now = Date.now();
     versionClickTimestampsRef.current = [
@@ -277,9 +282,9 @@ export function Settings({ settings, onChange, disabled, isWorkRunning, onExport
                   <NumberStepper label={i18n.shortBreak} value={settings.shortBreakMinutes}
                     onChange={(v) => update({ shortBreakMinutes: v })} min={1} max={30} disabled={disabled} unit={i18n.minutes} />
                   <Toggle label={i18n.autoStartBreak} checked={settings.autoStartBreak}
-                    onChange={(v) => update({ autoStartBreak: v })} disabled={settings.workMinutes > 25} />
+                    onChange={(v) => update({ autoStartBreak: v })} disabled={autoStartBreakDisabled} />
                   <Toggle label={i18n.autoStartWork} checked={settings.autoStartWork}
-                    onChange={(v) => update({ autoStartWork: v })} />
+                    onChange={(v) => update({ autoStartWork: v })} disabled={autoStartWorkDisabled} />
                 </div>
               </div>
 


### PR DESCRIPTION
## Issue
- Ref #105

## What changed
- wire `Auto-start Break` into the existing Settings lock window, while keeping the existing `workMinutes > 25` safeguard
- wire `Auto-start Work` into the same shared Settings lock window
- add native button `disabled` handling on the toggle control so the locked state blocks mouse, touch, and keyboard interaction instead of only muting the visuals

## Validation
- fresh local preview on `http://127.0.0.1:4173/`
- static checks: `PATH=/home/ycz87/projects/cosmelonclock/node_modules/.bin:$PATH eslint . && PATH=/home/ycz87/projects/cosmelonclock/node_modules/.bin:$PATH tsc -b && PATH=/home/ycz87/projects/cosmelonclock/node_modules/.bin:$PATH vite build`
- local proof captured at `/tmp/issue-105-proof/proof.json`
  - `/tmp/issue-105-proof/01-active-locked.png`
  - `/tmp/issue-105-proof/02-idle-restored.png`
  - `/tmp/issue-105-proof/03-break-safeguard.png`
