### PR TITLE
feat: unify Melodoro branding

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -60,9 +60,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tagName: v__VERSION__
-          releaseName: 'Watermelon Clock v__VERSION__'
+          releaseName: 'Melodoro v__VERSION__'
           releaseBody: |
-            🍉 Watermelon Clock v__VERSION__
+            🍉 Melodoro v__VERSION__
 
             Download the installer for your platform:
             - **Windows**: `.msi` or `.exe` (NSIS installer)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md - Cosmelon 项目规范（供 Claude Code 读取）
+# CLAUDE.md - Melodoro 项目规范（供 Claude Code 读取）
 
 ## 你的角色
 
@@ -6,7 +6,7 @@
 
 ## 项目概况
 
-- **产品：** 西瓜时钟（Watermelon Clock）— 番茄钟 + 农场养成
+- **产品：** Melodoro（中文名：西瓜时钟）— 番茄钟 + 农场养成
 - **技术栈：** React 19 + Vite 7 + Tailwind CSS 4 + TypeScript（strict）
 - **后端：** Cloudflare Workers（Hono）+ D1 数据库（独立仓库）
 - **线上地址：** https://clock.cosmelon.app

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,12 +1,12 @@
-# 🍉 西瓜时钟 — 产品文档
+# 🍉 Melodoro（西瓜时钟）— 产品文档
 
 ## 产品定位
-简洁优雅的专注计时器，基于番茄工作法，融入西瓜种植养成元素。
+Melodoro（中文名：西瓜时钟）是一款简洁优雅的专注计时器，基于番茄工作法，融入西瓜种植养成元素。
 
 ## 线上地址
 - **产品：** https://clock.cosmelon.app
 - **管理后台：** https://admin.cosmelon.app
-- **GitHub：** https://github.com/ycz87/cosmelon
+- **GitHub：** https://github.com/ycz87/melodoro
 
 ## 技术架构
 - **前端：** React 19 + Vite 7 + Tailwind CSS 4 + TypeScript（当前 v0.32.0）

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 🍉 西瓜时钟
+# 🍉 Melodoro（西瓜时钟）
 
-简洁优雅的专注计时器，基于番茄工作法（Pomodoro Technique）。
+Melodoro（中文名：西瓜时钟）是一款简洁优雅的专注计时器，基于番茄工作法（Pomodoro Technique）。
 
 **在线体验：** [clock.cosmelon.app](https://clock.cosmelon.app/)
 **当前版本：** v0.61.16

--- a/admin/index.html
+++ b/admin/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Cosmelon Admin</title>
+    <title>Melodoro Admin</title>
   </head>
   <body>
     <div id="root"></div>

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -37,7 +37,7 @@ export function App() {
     <div className="min-h-screen bg-gray-50">
       <header className="bg-white border-b border-gray-200">
         <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between">
-          <a href="#/" className="text-base font-semibold text-gray-900">🍉 Cosmelon Admin</a>
+          <a href="#/" className="text-base font-semibold text-gray-900">🍉 Melodoro Admin</a>
           <div className="flex items-center gap-4">
             <span className="text-sm text-gray-500">{getStoredAuth().email}</span>
             <button

--- a/admin/src/pages/Login.tsx
+++ b/admin/src/pages/Login.tsx
@@ -48,7 +48,7 @@ export function Login({ onLogin }: { onLogin: () => void }) {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <div className="w-full max-w-sm bg-white rounded-lg border border-gray-200 p-8">
-        <h1 className="text-xl font-semibold text-gray-900 mb-6 text-center">Cosmelon Admin</h1>
+        <h1 className="text-xl font-semibold text-gray-900 mb-6 text-center">Melodoro Admin</h1>
 
         {error && (
           <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="app_name">Cosmelon Clock</string>
-    <string name="title_activity_main">Cosmelon Clock</string>
+    <string name="app_name">Melodoro</string>
+    <string name="title_activity_main">Melodoro</string>
     <string name="package_name">app.cosmelon.clock</string>
     <string name="custom_url_scheme">app.cosmelon.clock</string>
 </resources>

--- a/auth/src/services/email.ts
+++ b/auth/src/services/email.ts
@@ -14,13 +14,13 @@ export async function sendVerificationEmail(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: 'Cosmelon <noreply@cosmelon.app>',
+      from: 'Melodoro <noreply@cosmelon.app>',
       to: [to],
       subject: `Your verification code / 您的验证码: ${code}`,
       html: `
         <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 420px; margin: 0 auto; padding: 32px; background: #ffffff;">
           <div style="text-align: center; margin-bottom: 24px;">
-            <img src="https://clock.cosmelon.app/logo.png" width="48" height="48" alt="Cosmelon" style="border: 0;" />
+            <img src="https://clock.cosmelon.app/logo.png" width="48" height="48" alt="Melodoro" style="border: 0;" />
           </div>
 
           <p style="color: #555; font-size: 14px; margin: 0 0 8px;">Your verification code is:</p>
@@ -35,7 +35,7 @@ export async function sendVerificationEmail(
 
           <hr style="border: none; border-top: 1px solid #eee; margin: 24px 0;" />
 
-          <p style="text-align: center; color: #bbb; font-size: 11px; margin: 0;">&copy; 2026 Cosmelon &middot; cosmelon.app</p>
+          <p style="text-align: center; color: #bbb; font-size: 11px; margin: 0;">&copy; 2026 Melodoro &middot; cosmelon.app</p>
         </div>
       `,
     }),

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -2,7 +2,7 @@ import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
   appId: 'app.cosmelon.clock',
-  appName: 'Cosmelon Clock',
+  appName: 'Melodoro',
   webDir: 'dist',
   server: {
     androidScheme: 'https'

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,11 +1,11 @@
-# 🍉 西瓜时钟 — 产品文档
+# 🍉 Melodoro（西瓜时钟）— 产品文档
 
 ## 项目信息
 
-- **产品名称：** 西瓜时钟（Watermelon Clock）
+- **产品名称：** Melodoro（中文名：西瓜时钟）
 - **线上地址：** https://clock.cosmelon.app/
 - **旧地址：** https://pomodoro-puce-seven-98.vercel.app/
-- **GitHub：** https://github.com/ycz87/pomodoro
+- **GitHub：** https://github.com/ycz87/melodoro
 - **技术栈：** React 19 + Vite 7 + Tailwind CSS 4 + TypeScript
 - **后端：** Cloudflare Workers（Hono）— API（watermelon-clock-api）+ Auth（cosmelon-auth）+ D1 数据库
 - **部署：** Cloudflare Pages（前端）+ Cloudflare Workers（API + Auth）

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "watermelon-clock"
 version = "0.1.2"
-description = "Watermelon Clock — A Pomodoro timer with watermelon growth theme"
+description = "Melodoro — A focus timer with watermelon growth theme"
 authors = ["Charles Yu"]
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
-  "productName": "Watermelon Clock",
+  "productName": "Melodoro",
   "version": "0.1.2",
   "identifier": "com.watermelonclock.app",
   "build": {
@@ -13,7 +13,7 @@
     "withGlobalTauri": false,
     "windows": [
       {
-        "title": "Watermelon Clock",
+        "title": "Melodoro",
         "width": 420,
         "height": 780,
         "minWidth": 360,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 /**
- * App — Watermelon Clock main application component
+ * App — Melodoro main application component
  *
  * Orchestrates the entire app: timer state, records, settings, audio, i18n,
  * and routes between Pomodoro mode and Project mode.

--- a/src/achievements/definitions.ts
+++ b/src/achievements/definitions.ts
@@ -10,11 +10,11 @@ export const STREAK_ACHIEVEMENTS: AchievementDef[] = [
   { id: 'S3', series: 'streak', nameZh: '半月坚持', nameEn: 'Fortnight Focus', descZh: '两周的坚持，西瓜田已经郁郁葱葱', descEn: 'Two weeks of persistence, your melon field is thriving', conditionZh: '连续打卡 14 天', conditionEn: '14-day streak', emoji: '🌿', target: 14, progressKey: 'currentStreak' },
   { id: 'S4', series: 'streak', nameZh: '钢铁意志', nameEn: 'Iron Will', descZh: '三十天，你证明了什么叫坚持', descEn: 'Thirty days — you proved what persistence means', conditionZh: '连续打卡 30 天', conditionEn: '30-day streak', emoji: '💪', target: 30, progressKey: 'currentStreak' },
   { id: 'S5', series: 'streak', nameZh: '百日传说', nameEn: 'Century Legend', descZh: '一百天不间断，你就是传说本身', descEn: '100 days unbroken — you are the legend', conditionZh: '连续打卡 100 天', conditionEn: '100-day streak', emoji: '👑', target: 100, progressKey: 'currentStreak' },
-  { id: 'S6', series: 'streak', nameZh: '累计百天', nameEn: 'Hundred Days', descZh: '一百天的陪伴，西瓜时钟已经是你生活的一部分', descEn: '100 days together — Watermelon Clock is part of your life', conditionZh: '累计使用天数 ≥100 天', conditionEn: '100+ total days', emoji: '📆', target: 100, progressKey: 'totalDays' },
+  { id: 'S6', series: 'streak', nameZh: '累计百天', nameEn: 'Hundred Days', descZh: '一百天的陪伴，西瓜时钟已经是你生活的一部分', descEn: '100 days together — Melodoro is part of your life', conditionZh: '累计使用天数 ≥100 天', conditionEn: '100+ total days', emoji: '📆', target: 100, progressKey: 'totalDays' },
   { id: 'S7', series: 'streak', nameZh: '早起鸟', nameEn: 'Early Bird', descZh: '清晨的西瓜田，露珠还在叶子上 🌅', descEn: 'Morning dew on the melon field 🌅', conditionZh: '早上 6:00-8:00 完成专注', conditionEn: 'Complete a session 6-8 AM', emoji: '🌅' },
   { id: 'S8', series: 'streak', nameZh: '夜猫子', nameEn: 'Night Owl', descZh: '夜深了，你的西瓜还在安静地生长 🌙', descEn: 'Late night, your melon grows quietly 🌙', conditionZh: '晚上 22:00-00:00 完成专注', conditionEn: 'Complete a session 10 PM-12 AM', emoji: '🌙' },
   { id: 'S9', series: 'streak', nameZh: '周末战士', nameEn: 'Weekend Warrior', descZh: '别人在休息，你在成长 💪', descEn: 'Others rest, you grow 💪', conditionZh: '周六和周日都完成了专注', conditionEn: 'Focus on both Saturday and Sunday', emoji: '⚔️' },
-  { id: 'S10', series: 'streak', nameZh: '西瓜元年', nameEn: 'Year One', descZh: '一整年，你和西瓜时钟一起走过了四季 🎂', descEn: 'A full year with Watermelon Clock 🎂', conditionZh: '首次使用满 365 天', conditionEn: '365 days since first use', emoji: '🎂', target: 365 },
+  { id: 'S10', series: 'streak', nameZh: '西瓜元年', nameEn: 'Year One', descZh: '一整年，你和西瓜时钟一起走过了四季 🎂', descEn: 'A full year with Melodoro 🎂', conditionZh: '首次使用满 365 天', conditionEn: '365 days since first use', emoji: '🎂', target: 365 },
 ];
 
 // ⏱️ 专注系列 (Focus)

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -16,8 +16,8 @@ const formatDuration = (minutes: number): string => {
 /** English translations */
 export const en: Messages = {
   // App
-  appName: 'Watermelon Clock',
-  appNameShort: 'WM Clock',
+  appName: 'Melodoro',
+  appNameShort: 'Melodoro',
 
   // Timer phases
   phaseWork: '🍉 Focus',
@@ -225,7 +225,7 @@ export const en: Messages = {
   // Guide
   guideTitle: '🍉 How to Use',
   guidePomodoro: 'Pomodoro Technique',
-  guidePomodoroDesc: 'Watermelon Clock uses the Pomodoro Technique to help you stay focused. Focus → Break → Focus → Break, simple cycle.',
+  guidePomodoroDesc: 'Melodoro uses the Pomodoro Technique to help you stay focused. Focus → Break → Focus → Break, simple cycle.',
   guideBasic: 'Getting Started',
   guideBasicItems: [
     'Tap play to start focusing',


### PR DESCRIPTION
## Issue
- Ref #107

## What changed
- unify the current user-facing English brand to `Melodoro` while preserving `西瓜时钟` in Chinese UI paths
- update the main English branding touchpoints in app/runtime copy, achievements, desktop/mobile packaging labels, admin/auth visible branding, release text, and maintained docs
- rename the GitHub repo from `ycz87/cosmelon` to `ycz87/melodoro`, then repoint the shared local remote and active team tooling/config refs
- align `README.md` with the adopted brand entry so the repo homepage also reads `Melodoro（西瓜时钟）`

## Validation
- static checks: `PATH=/home/ycz87/projects/cosmelonclock/node_modules/.bin:$PATH eslint . && PATH=/home/ycz87/projects/cosmelonclock/node_modules/.bin:$PATH tsc -b && PATH=/home/ycz87/projects/cosmelonclock/node_modules/.bin:$PATH vite build`
- fresh preview: `http://127.0.0.1:4175/`
- proof bundle: `/tmp/issue-107-proof/`
  - English UI: `/tmp/issue-107-proof/01-english-melodoro.png`
  - Chinese UI: `/tmp/issue-107-proof/02-chinese-xiguashizhong.png`
  - UI title capture: `/tmp/issue-107-proof/ui-proof.json`
  - docs/release excerpts: `/tmp/issue-107-proof/file-proof.txt`
  - README excerpt + redirect reality: `/tmp/issue-107-proof/readme-proof.txt`
  - renamed repo view: `/tmp/issue-107-proof/repo-view.json`
  - old repo redirect check: `/tmp/issue-107-proof/old-repo-redirect.txt`
  - old issue redirect check currently returns 404: `/tmp/issue-107-proof/old-issue-redirect.txt`

## Explicitly not changed
- `clock.cosmelon.app`, `auth.cosmelon.app`, `api.clock.cosmelon.app`, `admin.cosmelon.app`
- package identifiers like `app.cosmelon.clock` and `com.watermelonclock.app`
- worker/bucket names and other infra-only identifiers
