### PR TITLE
fix: canonicalize farm weather state

### DIFF
--- a/e2e/phase6-step3-weather-life.spec.ts
+++ b/e2e/phase6-step3-weather-life.spec.ts
@@ -1,4 +1,10 @@
 import { test, expect, type Page } from '@playwright/test';
+import {
+  migrateWeatherDebugOverride,
+  migrateWeatherState,
+  rotateWeatherState,
+  WEATHER_SWITCH_INTERVAL_MS,
+} from '../src/utils/weather';
 import type {
   AlienVisit,
   Creature,
@@ -13,13 +19,21 @@ interface DebugState {
   farm: Record<string, unknown>;
   shed: Record<string, unknown>;
   gene: Record<string, unknown>;
-  weatherState?: WeatherState;
+  weatherState?: unknown;
+  debugWeatherOverride?: unknown;
   creatures?: Creature[];
   alienVisit?: AlienVisit;
+  debugMode?: boolean;
 }
 
 const WEATHER_TYPES: Weather[] = ['sunny', 'cloudy', 'rainy', 'night', 'rainbow'];
 const CREATURE_TYPES: CreatureType[] = ['bee', 'butterfly', 'ladybug', 'bird'];
+
+function sequenceRandom(values: number[]): () => number {
+  const remaining = [...values];
+  const fallback = remaining.at(-1) ?? 0.5;
+  return () => (remaining.length > 0 ? remaining.shift() ?? fallback : fallback);
+}
 
 function getTodayKey(now: number = Date.now()): string {
   const date = new Date(now);
@@ -55,14 +69,17 @@ function createCreature(
 }
 
 function createSeedPayload(options?: {
+  now?: number;
   plots?: Plot[];
   farmOverrides?: Record<string, unknown>;
   shedOverrides?: Record<string, unknown>;
-  weatherState?: WeatherState;
+  weatherState?: unknown;
+  debugWeatherOverride?: unknown;
   creatures?: Creature[];
   alienVisit?: AlienVisit;
+  debugMode?: boolean;
 }): DebugState {
-  const now = Date.now();
+  const now = options?.now ?? Date.now();
   const todayKey = getTodayKey(now);
 
   return {
@@ -97,13 +114,34 @@ function createSeedPayload(options?: {
       fragments: [],
     },
     weatherState: options?.weatherState,
+    debugWeatherOverride: options?.debugWeatherOverride,
     creatures: options?.creatures,
     alienVisit: options?.alienVisit,
+    debugMode: options?.debugMode ?? false,
   };
 }
 
-function seedInit(page: Page, payload: DebugState) {
-  return page.addInitScript((state: DebugState) => {
+function seedInit(
+  page: Page,
+  payload: DebugState,
+  options?: { now?: number; randomSequence?: number[] },
+) {
+  return page.addInitScript(({ state, now, randomSequence }: {
+    state: DebugState;
+    now?: number;
+    randomSequence?: number[];
+  }) => {
+    if (typeof now === 'number') {
+      const fixedNow = now;
+      Date.now = () => fixedNow;
+    }
+
+    if (Array.isArray(randomSequence)) {
+      const remaining = [...randomSequence];
+      const fallback = remaining.at(-1) ?? 0.5;
+      Math.random = () => (remaining.length > 0 ? remaining.shift() ?? fallback : fallback);
+    }
+
     localStorage.clear();
     localStorage.setItem('pomodoro-guide-seen', '1');
     localStorage.setItem('pomodoro-settings', JSON.stringify(state.settings));
@@ -117,6 +155,12 @@ function seedInit(page: Page, payload: DebugState) {
       localStorage.removeItem('weatherState');
     }
 
+    if (state.debugWeatherOverride !== undefined) {
+      localStorage.setItem('weatherDebugOverride', JSON.stringify(state.debugWeatherOverride));
+    } else {
+      localStorage.removeItem('weatherDebugOverride');
+    }
+
     if (state.creatures !== undefined) {
       localStorage.setItem('creatures', JSON.stringify(state.creatures));
     } else {
@@ -128,7 +172,17 @@ function seedInit(page: Page, payload: DebugState) {
     } else {
       localStorage.removeItem('alienVisit');
     }
-  }, payload);
+
+    if (state.debugMode) {
+      localStorage.setItem('watermelon-debug', 'true');
+    } else {
+      localStorage.removeItem('watermelon-debug');
+    }
+  }, {
+    state: payload,
+    now: options?.now,
+    randomSequence: options?.randomSequence,
+  });
 }
 
 async function readStorage<T>(page: Page, key: string, fallback: T): Promise<T> {
@@ -146,7 +200,7 @@ async function readStorage<T>(page: Page, key: string, fallback: T): Promise<T> 
 async function goToFarm(page: Page) {
   await page.goto('/');
   await page.locator('header button').filter({ hasText: '🌱' }).first().click();
-  await expect(page.locator('.farm-grid-perspective')).toBeVisible();
+  await expect(page.locator('[data-testid="farm-v2-celestial-body"], .farm-grid-perspective').first()).toBeVisible();
 }
 
 test.describe('Phase 6 Step 3 - Weather & Life', () => {
@@ -258,5 +312,137 @@ test.describe('Phase 6 Step 3 - Weather & Life', () => {
     expect(Number.isFinite(alienVisit.current.appearedAt)).toBeTruthy();
     expect(Number.isFinite(alienVisit.current.expiresAt)).toBeTruthy();
     expect(alienVisit.current.expiresAt).toBeGreaterThan(alienVisit.current.appearedAt);
+  });
+
+  test('4. legacy weather migration repairs snowy and future lastChangeAt', async ({ page }) => {
+    const now = Date.UTC(2026, 3, 20, 12, 0, 0);
+
+    await seedInit(page, createSeedPayload({
+      now,
+      weatherState: {
+        current: 'snowy',
+        lastChangeAt: now + WEATHER_SWITCH_INTERVAL_MS,
+      },
+    }), { now });
+
+    await page.goto('/');
+
+    await expect.poll(async () => {
+      const state = await readStorage<WeatherState | null>(page, 'weatherState', null);
+      return state?.current ?? null;
+    }).toBe('cloudy');
+    await expect.poll(async () => {
+      const state = await readStorage<WeatherState | null>(page, 'weatherState', null);
+      return state?.lastChangeAt ?? null;
+    }).toBe(now);
+  });
+
+  test('5. null weather and malformed timestamps repair into canonical production weather', async ({ page }) => {
+    const now = Date.UTC(2026, 3, 20, 12, 0, 0);
+
+    expect(migrateWeatherState({ current: 'stormy', lastChangeAt: now }, now).current).toBe('rainy');
+    expect(
+      migrateWeatherState({ current: 'mystery-weather', lastChangeAt: 'invalid' }, now, sequenceRandom([0.51])),
+    ).toEqual({ current: 'cloudy', lastChangeAt: now });
+
+    await seedInit(page, createSeedPayload({
+      now,
+      weatherState: {
+        current: null,
+        lastChangeAt: 'invalid-timestamp',
+      },
+    }), {
+      now,
+      randomSequence: [0.51],
+    });
+
+    await page.goto('/');
+
+    await expect.poll(async () => {
+      const state = await readStorage<WeatherState | null>(page, 'weatherState', null);
+      return state?.current ?? null;
+    }).toBe('cloudy');
+    await expect.poll(async () => {
+      const state = await readStorage<WeatherState | null>(page, 'weatherState', null);
+      return state?.lastChangeAt ?? null;
+    }).toBe(now);
+  });
+
+  test('6. non-rainy production weather cannot rotate directly into rainbow', async ({ page }) => {
+    const now = Date.UTC(2026, 3, 20, 18, 0, 0);
+    const lastChangeAt = now - WEATHER_SWITCH_INTERVAL_MS - 1;
+
+    await seedInit(page, createSeedPayload({
+      now,
+      weatherState: {
+        current: 'sunny',
+        lastChangeAt,
+      },
+    }), {
+      now,
+      randomSequence: [0.99, 0.01],
+    });
+
+    await page.goto('/');
+
+    await expect.poll(async () => {
+      const state = await readStorage<WeatherState | null>(page, 'weatherState', null);
+      return state?.current ?? null;
+    }).toBe('sunny');
+    await expect.poll(async () => {
+      const state = await readStorage<WeatherState | null>(page, 'weatherState', null);
+      return state?.lastChangeAt ?? null;
+    }).toBe(lastChangeAt + WEATHER_SWITCH_INTERVAL_MS);
+  });
+
+  test('7. multi-slot catch-up advances gate slot by slot and can reach rainbow after rainy', () => {
+    const now = Date.UTC(2026, 3, 21, 0, 0, 0);
+    const lastChangeAt = now - (WEATHER_SWITCH_INTERVAL_MS * 2) - 1;
+
+    const state = rotateWeatherState(
+      {
+        current: 'sunny',
+        lastChangeAt,
+      },
+      now,
+      sequenceRandom([0.70, 0.01]),
+    );
+
+    expect(state.current).toBe('rainbow');
+    expect(state.lastChangeAt).toBe(lastChangeAt + (WEATHER_SWITCH_INTERVAL_MS * 2));
+  });
+
+  test('8. debug override stays separate from production truth and clear only removes the override', async ({ page }) => {
+    const now = Date.UTC(2026, 3, 21, 0, 0, 0);
+
+    expect(migrateWeatherDebugOverride('snowy')).toBe('cloudy');
+    expect(migrateWeatherDebugOverride('stormy')).toBe('rainy');
+
+    await seedInit(page, createSeedPayload({
+      now,
+      weatherState: {
+        current: 'rainbow',
+        lastChangeAt: now,
+      },
+      debugWeatherOverride: 'night',
+      debugMode: true,
+    }), { now });
+
+    await page.goto('/');
+    await expect(page.getByText('🧪 Debug Toolbar')).toBeVisible();
+
+    await expect.poll(async () => {
+      const state = await readStorage<WeatherState | null>(page, 'weatherState', null);
+      return state?.current ?? null;
+    }).toBe('rainbow');
+    await expect.poll(async () => readStorage<Weather | null>(page, 'weatherDebugOverride', null)).toBe('night');
+
+    await page.getByRole('button', { name: '清除天气' }).click();
+
+    await expect.poll(async () => readStorage<Weather | null>(page, 'weatherDebugOverride', null)).toBe(null);
+    await expect.poll(async () => {
+      const state = await readStorage<WeatherState | null>(page, 'weatherState', null);
+      return state?.current ?? null;
+    }).toBe('rainbow');
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,7 @@ import {
   applyMixerConfig, stopAllAmbience,
 } from './audio';
 import { getTodayKey } from './utils/time';
+import { DEBUG_WEATHER_ORDER } from './utils/weather';
 import { getStreak, getDayMinutes } from './utils/stats';
 import {
   applyGrowthWithMutation as applyGrowthWithMutationEngine,
@@ -120,7 +121,6 @@ import type {
   FusionHistory,
   Plot,
   VarietyId,
-  Weather,
 } from './types/farm';
 import { SHOP_ITEMS, PLOT_PRICES, SHOP_SEED_ITEM_TO_QUALITY } from './types/market';
 import type { ShopItemId, WeeklyItem } from './types/market';
@@ -128,7 +128,6 @@ import type { DarkMatterFusion, DarkMatterFusionType, FusionResult } from './typ
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const FUSION_HISTORY_KEY = 'watermelon-fusion-history';
-const DEBUG_WEATHER_ORDER: Weather[] = ['sunny', 'cloudy', 'rainy', 'night', 'rainbow', 'snowy', 'stormy'];
 
 interface FarmGrowthSegment {
   growthMinutes: number;
@@ -262,7 +261,13 @@ function App() {
   } = useFarmStorage();
   const { geneInventory, setGeneInventory, addFragment, removeFragment, removeFragmentsByGalaxy } = useGeneStorage();
   const { balance, addCoins, spendCoins, setBalance } = useMelonCoin();
-  const { weatherState, setWeatherState } = useWeather();
+  const {
+    effectiveWeather,
+    weatherState,
+    debugWeatherOverride,
+    setDebugWeatherOverride,
+  } = useWeather();
+  const currentProductionWeather = weatherState.current;
   const handleGrantWeeklyItem = useCallback((item: WeeklyItem) => {
     if (item.type === 'rare-gene-fragment') {
       const varietyDef = VARIETY_DEFS[item.data.varietyId];
@@ -1349,24 +1354,17 @@ function App() {
   }, [addShedItem]);
 
   const handleDebugCycleWeather = useCallback(() => {
-    setWeatherState((prev) => {
-      const currentIndex = prev.current === null ? -1 : DEBUG_WEATHER_ORDER.indexOf(prev.current);
-      const nextWeather = DEBUG_WEATHER_ORDER[(currentIndex + 1) % DEBUG_WEATHER_ORDER.length];
-      return {
-        ...prev,
-        current: nextWeather,
-        lastChangeAt: Date.now(),
-      };
+    setDebugWeatherOverride((prev) => {
+      const currentWeather = prev ?? currentProductionWeather;
+      const currentIndex = DEBUG_WEATHER_ORDER.indexOf(currentWeather);
+      const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % DEBUG_WEATHER_ORDER.length;
+      return DEBUG_WEATHER_ORDER[nextIndex];
     });
-  }, [setWeatherState]);
+  }, [currentProductionWeather, setDebugWeatherOverride]);
 
   const handleDebugClearWeather = useCallback(() => {
-    setWeatherState((prev) => ({
-      ...prev,
-      current: null,
-      lastChangeAt: Date.now(),
-    }));
-  }, [setWeatherState]);
+    setDebugWeatherOverride(null);
+  }, [setDebugWeatherOverride]);
 
   // Modal states
   const [showAbandonConfirm, setShowAbandonConfirm] = useState(false);
@@ -2109,7 +2107,7 @@ function App() {
             prismaticSeeds={shed.prismaticSeeds}
             darkMatterSeeds={shed.darkMatterSeeds}
             pendingRevealedNormalSeed={shed.pendingRevealedNormalSeed}
-            weather={weatherState.current}
+            weather={effectiveWeather}
             todayFocusMinutes={todayFocusMinutes}
             todayKey={todayKey}
             activeAlienVisit={alienVisit.current}
@@ -2313,9 +2311,10 @@ function App() {
             addCoins={handleDebugAddCoins}
             resetCoins={handleDebugResetCoins}
             addFarmItem={handleDebugAddFarmItem}
-            weather={weatherState.current}
+            weather={effectiveWeather}
             cycleWeather={handleDebugCycleWeather}
             clearWeather={handleDebugClearWeather}
+            isWeatherOverridden={debugWeatherOverride !== null}
             achievementUnlockedCount={Object.keys(achievements.data.unlocked).length}
             unlockAllAchievements={achievements.unlockAll}
             resetAchievements={achievements.resetAll}

--- a/src/components/DebugToolbar.tsx
+++ b/src/components/DebugToolbar.tsx
@@ -22,9 +22,10 @@ interface DebugToolbarProps {
   resetCoins: () => void;
   addFarmItem: (itemId: 'mutation-gun' | 'guardian-barrier' | 'moon-dew', count: number) => void;
   // Weather
-  weather: import('../types/farm').Weather | null;
+  weather: import('../types/farm').Weather;
   cycleWeather: () => void;
   clearWeather: () => void;
+  isWeatherOverridden: boolean;
   // Achievements
   achievementUnlockedCount: number;
   unlockAllAchievements: () => void;
@@ -85,8 +86,6 @@ const DEFENSE_ITEM_AMOUNTS = [1, 5] as const;
 const WEATHER_ICON: Record<Weather, string> = {
   sunny: '☀️',
   rainy: '🌧️',
-  snowy: '❄️',
-  stormy: '⛈️',
   cloudy: '☁️',
   night: '🌙',
   rainbow: '🌈',
@@ -106,6 +105,7 @@ export function DebugToolbar({
   weather,
   cycleWeather,
   clearWeather,
+  isWeatherOverridden,
   achievementUnlockedCount,
   unlockAllAchievements,
   resetAchievements,
@@ -120,9 +120,7 @@ export function DebugToolbar({
 
   const toolbarBg = withOpacity(theme.surface, 0.95);
   const actionBtnClass = 'text-[11px] rounded-[var(--radius-sm)] px-2 py-1 cursor-pointer transition-all duration-200 ease-in-out hover:-translate-y-0.5 disabled:opacity-40 disabled:cursor-not-allowed';
-  const weatherLabel = weather === null
-    ? 'null'
-    : `${WEATHER_ICON[weather] ?? '⛅'} ${weather}`;
+  const weatherLabel = `${WEATHER_ICON[weather]} ${weather}${isWeatherOverridden ? ' (override)' : ''}`;
 
   const handleInstantMature = useCallback(() => {
     const nowTimestamp = Date.now();

--- a/src/components/FarmPage.tsx
+++ b/src/components/FarmPage.tsx
@@ -55,7 +55,7 @@ interface FarmPageProps {
   prismaticSeeds: PrismaticSeed[];
   darkMatterSeeds: DarkMatterSeed[];
   pendingRevealedNormalSeed: PendingRevealedNormalSeed | null;
-  weather: Weather | null;
+  weather: Weather;
   todayFocusMinutes: number;
   todayKey: string;
   activeAlienVisit: AlienAppearance | null;
@@ -1021,7 +1021,7 @@ function SubTabHeader({ subTab, setSubTab, theme, t, gentle = false }: {
 // ─── 地块卡片 ───
 export interface PlotCardProps {
   plot: Plot;
-  weather: Weather | null;
+  weather: Weather;
   stolenRecord?: StolenRecord;
   nowTimestamp: number;
   theme: ReturnType<typeof useTheme>;

--- a/src/components/farm-v2/FarmPlotBoardV2.tsx
+++ b/src/components/farm-v2/FarmPlotBoardV2.tsx
@@ -4,7 +4,7 @@ import { FarmPlotTileV2 } from './FarmPlotTileV2';
 
 interface FarmPlotBoardV2Props {
   plots: Plot[];
-  weather: Weather | null;
+  weather: Weather;
   compactMode?: boolean;
   todayFocusMinutes: number;
   coinBalance: number;
@@ -220,7 +220,7 @@ function Cottage({ left, top }: { left: string; top: string }) {
   );
 }
 
-function FarmBackdropV2({ compactMode, weather }: { compactMode: boolean; weather: Weather | null }) {
+function FarmBackdropV2({ compactMode, weather }: { compactMode: boolean; weather: Weather }) {
   const isNarrowScreen = typeof window !== 'undefined' && window.innerWidth < 640;
   const useCompactMobilePolish = isNarrowScreen && compactMode;
   const useTightBackdrop = isNarrowScreen && !compactMode;

--- a/src/components/farm/SimpleFarmGrid.tsx
+++ b/src/components/farm/SimpleFarmGrid.tsx
@@ -14,7 +14,7 @@ import { IsometricPlotShell } from './IsometricPlotShell';
 
 interface SimpleFarmGridProps {
   plots: Plot[];
-  weather: Weather | null;
+  weather: Weather;
   nowTimestamp: number;
   activeTooltipPlotId: number | null;
   stolenRecordByPlotId?: Map<number, StolenRecord>;

--- a/src/components/farm/SkyLayer.tsx
+++ b/src/components/farm/SkyLayer.tsx
@@ -7,7 +7,7 @@ import { useMemo } from 'react';
 import type { Weather } from '../../types/farm';
 
 interface SkyLayerProps {
-  weather: Weather | null;
+  weather: Weather;
   currentTime: Date;
 }
 
@@ -44,12 +44,10 @@ const CLOUD_LAYOUTS: Record<number, CelestialPosition[]> = {
   ],
 };
 
-function getCloudCount(weather: Weather | null): number {
-  if (weather === null) return 0;
+function getCloudCount(weather: Weather): number {
   if (weather === 'sunny') return 1;
   if (weather === 'cloudy') return 4;
-  if (weather === 'rainy' || weather === 'snowy') return 5;
-  if (weather === 'stormy') return 6;
+  if (weather === 'rainy') return 5;
   return 0;
 }
 
@@ -74,7 +72,7 @@ export function SkyLayer({ weather, currentTime }: SkyLayerProps) {
   );
 
   return (
-    <div className="w-full h-full relative" data-weather={weather ?? 'clear'}>
+    <div className="w-full h-full relative" data-weather={weather}>
       <span
         className={`absolute z-10 opacity-90 select-none pointer-events-none ${isNight ? 'text-5xl' : 'text-6xl'}`}
         style={{

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,20 +1,27 @@
 import { useEffect } from 'react';
 import { useLocalStorage } from './useLocalStorage';
-import type { WeatherState } from '../types/farm';
+import type { WeatherDebugOverride, WeatherState } from '../types/farm';
 import {
   createInitialWeatherState,
   getMsUntilNextWeatherSwitch,
+  migrateWeatherDebugOverride,
   migrateWeatherState,
   rotateWeatherState,
 } from '../utils/weather';
 
 const WEATHER_STORAGE_KEY = 'weatherState';
+const WEATHER_DEBUG_OVERRIDE_STORAGE_KEY = 'weatherDebugOverride';
 
 export function useWeather() {
   const [weatherState, setWeatherState] = useLocalStorage<WeatherState>(
     WEATHER_STORAGE_KEY,
     createInitialWeatherState(),
     migrateWeatherState,
+  );
+  const [debugWeatherOverride, setDebugWeatherOverride] = useLocalStorage<WeatherDebugOverride>(
+    WEATHER_DEBUG_OVERRIDE_STORAGE_KEY,
+    null,
+    migrateWeatherDebugOverride,
   );
 
   // App open check: apply missed rotations while offline.
@@ -35,7 +42,10 @@ export function useWeather() {
   }, [weatherState, setWeatherState]);
 
   return {
+    effectiveWeather: debugWeatherOverride ?? weatherState.current,
     weatherState,
     setWeatherState,
+    debugWeatherOverride,
+    setDebugWeatherOverride,
   };
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -598,8 +598,6 @@ export const de: Messages = {
     rainy: 'Regnerisch',
     night: 'Nacht',
     rainbow: 'Regenbogen',
-    snowy: 'Schnee',
-    stormy: 'Sturm',
   }[weather] ?? weather),
   farmReveal: 'Ding! Es ist—',
   farmNewVariety: 'Neue Sorte!',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -598,8 +598,6 @@ export const en: Messages = {
     rainy: 'Rainy',
     night: 'Night',
     rainbow: 'Rainbow',
-    snowy: 'Snowy',
-    stormy: 'Stormy',
   }[weather] ?? weather),
   farmReveal: 'Ding! It\'s—',
   farmNewVariety: 'New Variety!',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -598,8 +598,6 @@ export const es: Messages = {
     rainy: 'Lluvioso',
     night: 'Noche',
     rainbow: 'Arcoíris',
-    snowy: 'Nieve',
-    stormy: 'Tormenta',
   }[weather] ?? weather),
   farmReveal: '¡Din! Es—',
   farmNewVariety: '¡Nueva variedad!',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -598,8 +598,6 @@ export const fr: Messages = {
     rainy: 'Pluvieux',
     night: 'Nuit',
     rainbow: 'Arc-en-ciel',
-    snowy: 'Neige',
-    stormy: 'Tempête',
   }[weather] ?? weather),
   farmReveal: 'Ding ! C\'est—',
   farmNewVariety: 'Nouvelle variété !',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -598,8 +598,6 @@ export const ja: Messages = {
     rainy: '雨',
     night: '夜',
     rainbow: '虹',
-    snowy: '雪',
-    stormy: '嵐',
   }[weather] ?? weather),
   farmReveal: 'ピン！正体は——',
   farmNewVariety: '新品種！',

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -598,8 +598,6 @@ export const ko: Messages = {
     rainy: '비',
     night: '밤',
     rainbow: '무지개',
-    snowy: '눈',
-    stormy: '폭풍',
   }[weather] ?? weather),
   farmReveal: '딩! 정체는——',
   farmNewVariety: '새 품종!',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -68,8 +68,6 @@ export const ru: Messages = {
     rainy: 'Дождь',
     night: 'Ночь',
     rainbow: 'Радуга',
-    snowy: 'Снег',
-    stormy: 'Буря',
   }[weather] ?? weather),
   alienMelonGreeting: '👽 Арбузный пришелец: в твоём поле мощная жизненная энергия. Продолжай сажать!',
   alienMutationDoctor: '🧪 Доктор Мутация: обнаружен ген-модификатор. Мутационная волна нестабильна!',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -600,8 +600,6 @@ export const zh: Messages = {
     rainy: '雨天',
     night: '夜晚',
     rainbow: '彩虹',
-    snowy: '雪天',
-    stormy: '暴风雨',
   }[weather] ?? weather),
   farmReveal: '叮！原来是——',
   farmNewVariety: '新品种！',

--- a/src/i18n/locales/zhTW.ts
+++ b/src/i18n/locales/zhTW.ts
@@ -600,8 +600,6 @@ export const zhTW: Messages = {
     rainy: '雨天',
     night: '夜晚',
     rainbow: '彩虹',
-    snowy: '雪天',
-    stormy: '暴風雨',
   }[weather] ?? weather),
   farmReveal: '叮！原來是——',
   farmNewVariety: '新品種！',

--- a/src/types/farm.ts
+++ b/src/types/farm.ts
@@ -557,10 +557,11 @@ export const GROWTH_STAGES: StageDef[] = [
 ];
 
 // ─── Farm ambience (Phase 6) ───
-export type Weather = 'sunny' | 'cloudy' | 'rainy' | 'night' | 'rainbow' | 'snowy' | 'stormy';
+export type Weather = 'sunny' | 'cloudy' | 'rainy' | 'night' | 'rainbow';
+export type WeatherDebugOverride = Weather | null;
 
 export interface WeatherState {
-  current: Weather | null;
+  current: Weather;
   lastChangeAt: number; // ms timestamp
 }
 

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -1,61 +1,97 @@
-import type { Weather, WeatherState } from '../types/farm';
+import type { Weather, WeatherDebugOverride, WeatherState } from '../types/farm';
 
 export const WEATHER_SWITCH_INTERVAL_MS = 6 * 60 * 60 * 1000;
-const RAINBOW_CHANCE = 0.05;
+export const DEBUG_WEATHER_ORDER: Weather[] = ['sunny', 'cloudy', 'rainy', 'night', 'rainbow'];
 
-const BASE_WEATHERS: Weather[] = ['sunny', 'cloudy', 'rainy', 'night'];
+const RAINBOW_CHANCE = 0.05;
+const DEFAULT_WEATHER: Weather = 'sunny';
 
 function isWeather(value: unknown): value is Weather {
-  return typeof value === 'string' && (
-    value === 'sunny'
-    || value === 'cloudy'
-    || value === 'rainy'
-    || value === 'night'
-    || value === 'rainbow'
-    || value === 'snowy'
-    || value === 'stormy'
-  );
+  return typeof value === 'string' && DEBUG_WEATHER_ORDER.includes(value as Weather);
 }
 
-export function rollWeather(randomFn: () => number = Math.random): Weather {
+function repairWeather(value: unknown, fallbackWeather: Weather = DEFAULT_WEATHER): Weather {
+  if (isWeather(value)) {
+    return value;
+  }
+  if (value === 'snowy') {
+    return 'cloudy';
+  }
+  if (value === 'stormy') {
+    return 'rainy';
+  }
+  return fallbackWeather;
+}
+
+function normalizeLastChangeAt(value: unknown, now: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value > now) {
+    return now;
+  }
+  return value;
+}
+
+export function rollWeather(previousWeather: Weather, randomFn: () => number = Math.random): Weather {
   const roll = randomFn();
-  if (roll < RAINBOW_CHANCE) {
-    return 'rainbow';
+
+  if (previousWeather === 'rainy') {
+    if (roll < RAINBOW_CHANCE) return 'rainbow';
+    if (roll < 0.45) return 'sunny';
+    if (roll < 0.70) return 'cloudy';
+    if (roll < 0.85) return 'rainy';
+    return 'night';
   }
 
-  const normalized = (roll - RAINBOW_CHANCE) / (1 - RAINBOW_CHANCE);
-  const index = Math.min(
-    BASE_WEATHERS.length - 1,
-    Math.floor(normalized * BASE_WEATHERS.length),
-  );
-  return BASE_WEATHERS[index];
+  if (roll < 0.40) return 'sunny';
+  if (roll < 0.65) return 'cloudy';
+  if (roll < 0.85) return 'rainy';
+  return 'night';
 }
 
-export function createInitialWeatherState(now: number = Date.now()): WeatherState {
+export function createInitialWeatherState(
+  now: number = Date.now(),
+  randomFn: () => number = Math.random,
+): WeatherState {
   return {
-    current: rollWeather(),
+    current: rollWeather(DEFAULT_WEATHER, randomFn),
     lastChangeAt: now,
   };
 }
 
-export function migrateWeatherState(raw: unknown): WeatherState {
-  const now = Date.now();
-  if (!raw || typeof raw !== 'object') return createInitialWeatherState(now);
+export function migrateWeatherState(
+  raw: unknown,
+  now: number = Date.now(),
+  randomFn: () => number = Math.random,
+): WeatherState {
+  if (!raw || typeof raw !== 'object') {
+    return createInitialWeatherState(now, randomFn);
+  }
 
   const candidate = raw as Record<string, unknown>;
-  const current = candidate.current === null
-    ? null
-    : isWeather(candidate.current)
-      ? candidate.current
-      : rollWeather();
-  const lastChangeAt = typeof candidate.lastChangeAt === 'number' && Number.isFinite(candidate.lastChangeAt)
-    ? candidate.lastChangeAt
-    : now;
+  const current = isWeather(candidate.current)
+    ? candidate.current
+    : candidate.current === 'snowy'
+      ? 'cloudy'
+      : candidate.current === 'stormy'
+        ? 'rainy'
+        : rollWeather(DEFAULT_WEATHER, randomFn);
 
   return {
     current,
-    lastChangeAt,
+    lastChangeAt: normalizeLastChangeAt(candidate.lastChangeAt, now),
   };
+}
+
+export function migrateWeatherDebugOverride(raw: unknown): WeatherDebugOverride {
+  if (raw === null || typeof raw === 'undefined') {
+    return null;
+  }
+  if (raw === 'snowy') {
+    return 'cloudy';
+  }
+  if (raw === 'stormy') {
+    return 'rainy';
+  }
+  return isWeather(raw) ? raw : null;
 }
 
 export function rotateWeatherState(
@@ -64,41 +100,36 @@ export function rotateWeatherState(
   randomFn: () => number = Math.random,
 ): WeatherState {
   if (!Number.isFinite(now)) return state;
-  if (!Number.isFinite(state.lastChangeAt)) {
-    return {
-      current: rollWeather(randomFn),
-      lastChangeAt: now,
-    };
-  }
 
-  if (state.lastChangeAt > now) {
-    return {
-      ...state,
-      lastChangeAt: now,
-    };
-  }
-
-  const elapsed = now - state.lastChangeAt;
+  const current = repairWeather(state.current, DEFAULT_WEATHER);
+  const lastChangeAt = normalizeLastChangeAt(state.lastChangeAt, now);
+  const elapsed = now - lastChangeAt;
   const rotations = Math.floor(elapsed / WEATHER_SWITCH_INTERVAL_MS);
-  if (rotations <= 0) return state;
+  if (rotations <= 0) {
+    return {
+      current,
+      lastChangeAt,
+    };
+  }
 
-  let nextWeather = state.current;
+  let nextWeather = current;
   for (let i = 0; i < rotations; i += 1) {
-    nextWeather = rollWeather(randomFn);
+    nextWeather = rollWeather(nextWeather, randomFn);
   }
 
   return {
     current: nextWeather,
-    lastChangeAt: state.lastChangeAt + rotations * WEATHER_SWITCH_INTERVAL_MS,
+    lastChangeAt: lastChangeAt + rotations * WEATHER_SWITCH_INTERVAL_MS,
   };
 }
 
 export function getMsUntilNextWeatherSwitch(state: WeatherState, now: number = Date.now()): number {
-  if (state.lastChangeAt > now) {
+  if (!Number.isFinite(now)) {
     return WEATHER_SWITCH_INTERVAL_MS;
   }
 
-  const elapsed = now - state.lastChangeAt;
+  const lastChangeAt = normalizeLastChangeAt(state.lastChangeAt, now);
+  const elapsed = now - lastChangeAt;
   const remainder = elapsed % WEATHER_SWITCH_INTERVAL_MS;
   if (remainder === 0) {
     return WEATHER_SWITCH_INTERVAL_MS;


### PR DESCRIPTION
## Summary
- canonicalize production farm weather to the single `sunny/cloudy/rainy/night/rainbow` contract
- keep `weatherState + lastChangeAt` as the production truth while moving debug override into its own storage path
- add focused proof for migration repair, rainbow gating, multi-slot catch-up, and debug override isolation

## Testing
- npm run lint
- npm run build
- npx playwright test e2e/phase6-step3-weather-life.spec.ts --project=desktop

Refs #118
