### PR TITLE
feat: add farm weather badge

### DIFF
--- a/e2e/farm-weather-badge.spec.ts
+++ b/e2e/farm-weather-badge.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import { en } from '../src/i18n/locales/en';
+import { zh } from '../src/i18n/locales/zh';
+import type { Plot, Weather, WeatherState } from '../src/types/farm';
+import { WEATHER_ICON_MAP } from '../src/utils/weather';
+
+interface SeedState {
+  settings: Record<string, unknown>;
+  farm: Record<string, unknown>;
+  shed: Record<string, unknown>;
+  gene: Record<string, unknown>;
+  weatherState?: WeatherState;
+  debugWeatherOverride?: Weather | null;
+  debugMode?: boolean;
+}
+
+function getTodayKey(now: number = Date.now()): string {
+  const date = new Date(now);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+function createEmptyPlot(id: number): Plot {
+  return {
+    id,
+    state: 'empty',
+    progress: 0,
+    mutationStatus: 'none',
+    mutationChance: 0.02,
+    isMutant: false,
+    accumulatedMinutes: 0,
+    lastActivityTimestamp: 0,
+    hasTracker: false,
+  };
+}
+
+function createSeedState(options?: {
+  language?: 'zh' | 'en';
+  now?: number;
+  weather?: Weather;
+  debugMode?: boolean;
+}): SeedState {
+  const now = options?.now ?? Date.now();
+
+  return {
+    settings: {
+      workMinutes: 25,
+      shortBreakMinutes: 5,
+      theme: 'dark',
+      language: options?.language ?? 'zh',
+    },
+    farm: {
+      plots: Array.from({ length: 4 }, (_, index) => createEmptyPlot(index)),
+      collection: [],
+      lastActiveDate: getTodayKey(now),
+      consecutiveInactiveDays: 0,
+      lastActivityTimestamp: now,
+      guardianBarrierDate: '',
+      stolenRecords: [],
+    },
+    shed: {
+      seeds: { normal: 0, epic: 0, legendary: 0 },
+      items: {},
+      totalSliced: 0,
+      pity: { epicPity: 0, legendaryPity: 0 },
+      injectedSeeds: [],
+      hybridSeeds: [],
+      prismaticSeeds: [],
+      darkMatterSeeds: [],
+    },
+    gene: {
+      fragments: [],
+    },
+    weatherState: {
+      current: options?.weather ?? 'sunny',
+      lastChangeAt: now,
+    },
+    debugMode: options?.debugMode ?? false,
+  };
+}
+
+function seedInit(page: Page, state: SeedState) {
+  return page.addInitScript((payload: SeedState) => {
+    localStorage.clear();
+    localStorage.setItem('pomodoro-guide-seen', '1');
+    localStorage.setItem('pomodoro-settings', JSON.stringify(payload.settings));
+    localStorage.setItem('watermelon-farm', JSON.stringify(payload.farm));
+    localStorage.setItem('watermelon-shed', JSON.stringify(payload.shed));
+    localStorage.setItem('watermelon-genes', JSON.stringify(payload.gene));
+
+    if (payload.weatherState) {
+      localStorage.setItem('weatherState', JSON.stringify(payload.weatherState));
+    }
+
+    if (payload.debugWeatherOverride !== undefined) {
+      localStorage.setItem('weatherDebugOverride', JSON.stringify(payload.debugWeatherOverride));
+    } else {
+      localStorage.removeItem('weatherDebugOverride');
+    }
+
+    if (payload.debugMode) {
+      localStorage.setItem('watermelon-debug', 'true');
+    } else {
+      localStorage.removeItem('watermelon-debug');
+    }
+  }, state);
+}
+
+async function goToFarm(page: Page) {
+  await page.goto('/');
+  await page.locator('header button').filter({ hasText: '🌱' }).first().click();
+  await expect(page.locator('[data-testid="farm-v2-weather-badge"]')).toBeVisible();
+}
+
+async function captureProof(page: Page, testInfo: TestInfo, name: string) {
+  await page.screenshot({
+    path: testInfo.outputPath(name),
+    fullPage: false,
+  });
+}
+
+test.describe('Farm weather badge', () => {
+  test('desktop badge stays in sync with weather updates and uses zh weather names', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'desktop proof only');
+    await seedInit(page, createSeedState({ language: 'zh', weather: 'sunny', debugMode: true }));
+    await goToFarm(page);
+
+    const badge = page.locator('[data-testid="farm-v2-weather-badge"]');
+    await expect(badge).toContainText(WEATHER_ICON_MAP.sunny);
+    await expect(badge).toContainText(zh.farmWeatherName('sunny'));
+    await captureProof(page, testInfo, 'desktop-farm-weather-badge.png');
+
+    await page.getByRole('button', { name: '切换天气' }).click();
+    await expect(badge).toContainText(WEATHER_ICON_MAP.cloudy);
+    await expect(badge).toContainText(zh.farmWeatherName('cloudy'));
+    await expect.poll(async () => page.evaluate(() => JSON.parse(localStorage.getItem('weatherDebugOverride') ?? 'null'))).toBe('cloudy');
+  });
+
+  test('mobile badge is visible below the HUD pills, stays off the plot area, and uses en weather names', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile', 'mobile proof only');
+    await seedInit(page, createSeedState({ language: 'en', weather: 'rainbow' }));
+    await goToFarm(page);
+
+    const badge = page.locator('[data-testid="farm-v2-weather-badge"]');
+    const board = page.locator('[data-testid="farm-plot-board-v2"]');
+
+    await expect(badge).toContainText(WEATHER_ICON_MAP.rainbow);
+    await expect(badge).toContainText(en.farmWeatherName('rainbow'));
+    await captureProof(page, testInfo, 'mobile-farm-weather-badge.png');
+
+    const badgeBox = await badge.boundingBox();
+    const boardBox = await board.boundingBox();
+
+    expect(badgeBox).not.toBeNull();
+    expect(boardBox).not.toBeNull();
+    expect((badgeBox?.y ?? 0) + (badgeBox?.height ?? 0)).toBeLessThan(boardBox?.y ?? 0);
+  });
+});

--- a/src/components/DebugToolbar.tsx
+++ b/src/components/DebugToolbar.tsx
@@ -5,7 +5,8 @@
  */
 import { useCallback, useState } from 'react';
 import { useTheme } from '../hooks/useTheme';
-import { VARIETY_DEFS, type Weather } from '../types/farm';
+import { WEATHER_ICON_MAP } from '../utils/weather';
+import { VARIETY_DEFS } from '../types/farm';
 
 interface DebugToolbarProps {
   // Warehouse actions (migrated from Settings testMode)
@@ -83,13 +84,6 @@ const MULTIPLIERS = [1, 100, 1000, 10000] as const;
 const COIN_AMOUNTS = [100, 1000, 10000] as const;
 const MUTATION_RAY_AMOUNTS = [1, 5, 10] as const;
 const DEFENSE_ITEM_AMOUNTS = [1, 5] as const;
-const WEATHER_ICON: Record<Weather, string> = {
-  sunny: '☀️',
-  rainy: '🌧️',
-  cloudy: '☁️',
-  night: '🌙',
-  rainbow: '🌈',
-};
 
 export function DebugToolbar({
   addItems,
@@ -120,7 +114,7 @@ export function DebugToolbar({
 
   const toolbarBg = withOpacity(theme.surface, 0.95);
   const actionBtnClass = 'text-[11px] rounded-[var(--radius-sm)] px-2 py-1 cursor-pointer transition-all duration-200 ease-in-out hover:-translate-y-0.5 disabled:opacity-40 disabled:cursor-not-allowed';
-  const weatherLabel = `${WEATHER_ICON[weather]} ${weather}${isWeatherOverridden ? ' (override)' : ''}`;
+  const weatherLabel = `${WEATHER_ICON_MAP[weather]} ${weather}${isWeatherOverridden ? ' (override)' : ''}`;
 
   const handleInstantMature = useCallback(() => {
     const nowTimestamp = Date.now();

--- a/src/components/FarmPage.tsx
+++ b/src/components/FarmPage.tsx
@@ -676,6 +676,7 @@ export function FarmPage({
               compactMode={compactShell}
               plots={farm.plots}
               weather={weather}
+              weatherLabel={t.farmWeatherName(weather)}
               todayFocusMinutes={todayFocusMinutes}
               coinBalance={coinBalance}
               plantableSeedCount={totalPlantableSeeds}

--- a/src/components/farm-v2/FarmPlotBoardV2.tsx
+++ b/src/components/farm-v2/FarmPlotBoardV2.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
 import type { Plot, Weather } from '../../types/farm';
+import { WEATHER_ICON_MAP } from '../../utils/weather';
 import { FarmPlotTileV2 } from './FarmPlotTileV2';
 
 interface FarmPlotBoardV2Props {
   plots: Plot[];
   weather: Weather;
+  weatherLabel: string;
   compactMode?: boolean;
   todayFocusMinutes: number;
   coinBalance: number;
@@ -26,12 +28,16 @@ function mapPlotStateToTileState(plot: Plot | null) {
 
 function FarmHudV2({
   compactMode,
+  weather,
+  weatherLabel,
   todayFocusMinutes,
   coinBalance,
   plantableSeedCount,
   harvestablePlotCount,
 }: {
   compactMode: boolean;
+  weather: Weather;
+  weatherLabel: string;
   todayFocusMinutes: number;
   coinBalance: number;
   plantableSeedCount: number;
@@ -47,28 +53,48 @@ function FarmHudV2({
   return (
     <div className="pointer-events-none absolute inset-x-0 top-0 z-40">
       <div
-        className="mx-auto flex h-10 w-full items-center justify-center gap-1.5 px-2 sm:h-11 sm:gap-2 sm:px-4"
-        style={{
-          maxWidth: compactMode ? '100%' : '940px',
-          borderBottom: '1px solid rgba(100,145,175,0.22)',
-          background: 'linear-gradient(180deg, rgba(167,217,242,0.42) 0%, rgba(167,217,242,0.08) 100%)',
-        }}
+        className="mx-auto w-full px-2 pt-1 sm:px-4 sm:pt-2"
+        style={{ maxWidth: compactMode ? '100%' : '940px' }}
       >
-        {badgeItems.map((badge) => (
+        <div
+          className="flex h-10 w-full items-center justify-center gap-1.5 px-2 sm:h-11 sm:gap-2 sm:px-4"
+          style={{
+            borderBottom: '1px solid rgba(100,145,175,0.22)',
+            background: 'linear-gradient(180deg, rgba(167,217,242,0.42) 0%, rgba(167,217,242,0.08) 100%)',
+          }}
+        >
+          {badgeItems.map((badge) => (
+            <div
+              key={`farm-v2-hud-${badge.label}`}
+              className="flex items-center gap-1 rounded-full border px-2 py-[3px] text-[11px] font-semibold sm:px-3 sm:text-xs"
+              style={{
+                borderColor: '#b57d4a',
+                color: '#5d3a1f',
+                background: 'linear-gradient(180deg, rgba(255,244,216,0.95) 0%, rgba(247,226,188,0.9) 100%)',
+                boxShadow: '0 1px 0 rgba(255,255,255,0.34) inset',
+              }}
+            >
+              <span>{badge.icon}</span>
+              <span>{badge.label}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-1.5 flex justify-center">
           <div
-            key={`farm-v2-hud-${badge.label}`}
-            className="flex items-center gap-1 rounded-full border px-2 py-[3px] text-[11px] font-semibold sm:px-3 sm:text-xs"
+            data-testid="farm-v2-weather-badge"
+            className="flex items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1 text-[11px] font-semibold sm:gap-2 sm:px-3.5 sm:text-xs"
             style={{
-              borderColor: '#b57d4a',
-              color: '#5d3a1f',
-              background: 'linear-gradient(180deg, rgba(255,244,216,0.95) 0%, rgba(247,226,188,0.9) 100%)',
-              boxShadow: '0 1px 0 rgba(255,255,255,0.34) inset',
+              borderColor: 'rgba(91, 146, 128, 0.32)',
+              color: '#21503b',
+              background: 'linear-gradient(180deg, rgba(245,255,249,0.96) 0%, rgba(229,247,237,0.92) 100%)',
+              boxShadow: '0 1px 0 rgba(255,255,255,0.42) inset',
             }}
           >
-            <span>{badge.icon}</span>
-            <span>{badge.label}</span>
+            <span aria-hidden="true">{WEATHER_ICON_MAP[weather]}</span>
+            <span>{weatherLabel}</span>
           </div>
-        ))}
+        </div>
       </div>
     </div>
   );
@@ -539,6 +565,7 @@ function FarmBoardSceneDecorV2({
 export function FarmPlotBoardV2({
   plots,
   weather,
+  weatherLabel,
   compactMode = false,
   todayFocusMinutes,
   coinBalance,
@@ -587,6 +614,7 @@ export function FarmPlotBoardV2({
     : useTightMobileSpacing
       ? 'calc(env(safe-area-inset-bottom, 0px) + clamp(10px, 1.5vh, 16px))'
       : 'clamp(18px, 2.5vh, 28px)';
+  const hudWeatherBadgeOffset = useTightMobileSpacing ? 42 : compactMode ? 38 : 34;
 
   return (
     <div
@@ -600,6 +628,8 @@ export function FarmPlotBoardV2({
       <FarmBackdropV2 compactMode={compactMode} weather={weather} />
       <FarmHudV2
         compactMode={compactMode}
+        weather={weather}
+        weatherLabel={weatherLabel}
         todayFocusMinutes={todayFocusMinutes}
         coinBalance={coinBalance}
         plantableSeedCount={plantableSeedCount}
@@ -609,7 +639,7 @@ export function FarmPlotBoardV2({
       <div
         className={`relative z-20 mx-auto flex w-full justify-center ${useTightMobileSpacing ? 'px-2 sm:px-2' : 'px-0 sm:px-2'}`}
         style={{
-          paddingTop: boardPaddingTop,
+          paddingTop: `calc(${boardPaddingTop} + ${hudWeatherBadgeOffset}px)`,
           paddingBottom: boardPaddingBottom,
         }}
       >

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -2,6 +2,13 @@ import type { Weather, WeatherDebugOverride, WeatherState } from '../types/farm'
 
 export const WEATHER_SWITCH_INTERVAL_MS = 6 * 60 * 60 * 1000;
 export const DEBUG_WEATHER_ORDER: Weather[] = ['sunny', 'cloudy', 'rainy', 'night', 'rainbow'];
+export const WEATHER_ICON_MAP: Record<Weather, string> = {
+  sunny: '☀️',
+  cloudy: '☁️',
+  rainy: '🌧️',
+  night: '🌙',
+  rainbow: '🌈',
+};
 
 const RAINBOW_CHANCE = 0.05;
 const DEFAULT_WEATHER: Weather = 'sunny';


### PR DESCRIPTION
## Summary
- add a minimal weather badge to the default `FarmPlotBoardV2` scene HUD, centered below the four existing status pills
- bind the badge to `FarmPage`'s current `weather` prop and reuse `t.farmWeatherName(weather)` for localized labels
- move the canonical weather emoji mapping into shared weather utils and cover desktop/mobile proof in Playwright

## Testing
- `npm run lint`
- `npm run build`
- `npx playwright test e2e/farm-weather-badge.spec.ts --project=desktop --project=mobile`

Refs #119
