### PR TITLE
chore: bump app version to 0.61.17

### DIFF
--- a/artifacts/issue-120/PROOF.md
+++ b/artifacts/issue-120/PROOF.md
@@ -29,3 +29,9 @@
 ## Notes
 - Weather visuals still consume the existing `weather` prop only
 - Rain and rainbow live under the backdrop `pointer-events-none` layer, so plot click / plant / harvest behavior is unchanged
+
+## Follow-up Version Gate
+- `package.json` version: `0.61.17`
+- `package-lock.json` top-level version: `0.61.17`
+- Build verification: `npm run build` prints `pomodoro@0.61.17 build`
+- Preview verification: local preview DOM renders page-corner version text `v0.61.17`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pomodoro",
-  "version": "0.61.15",
+  "version": "0.61.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pomodoro",
-      "version": "0.61.15",
+      "version": "0.61.17",
       "dependencies": {
         "@capacitor/android": "^8.1.0",
         "@capacitor/cli": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pomodoro",
   "private": true,
-  "version": "0.61.16",
+  "version": "0.61.17",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Issue
- #120
- supersedes #127, which used a non-canonical head ref and could not pass the workflow merge helper

## What changed
- bump `package.json` from `0.61.16` to `0.61.17`
- sync `package-lock.json` top-level version to `0.61.17`
- append version-gate proof notes to `artifacts/issue-120/PROOF.md`

## Verification
- `npm run build`
- local preview page-corner version text shows `v0.61.17`

## Scope guard
- canonical branch: `feature/issue-120`
- diff intentionally limited to `package.json`, `package-lock.json`, and `artifacts/issue-120/PROOF.md`
