### PR TITLE
feat: add farm weather scene transition overlay

### DIFF
--- a/artifacts/issue-121/PROOF.md
+++ b/artifacts/issue-121/PROOF.md
@@ -1,0 +1,48 @@
+# Issue #121 Proof
+
+## Scope
+- Default `FarmPlotBoardV2` V2 main scene only
+- Trigger source stays at the incoming `weather` prop, no data-chain or truth-source changes
+- No HUD, weather badge, board matrix, or plot interaction layout changes
+- Transition stays lightweight: previous-weather overlay fade only, no new particle system or full-screen effect
+
+## Trigger Contract
+- `src/components/farm-v2/FarmPlotBoardV2.tsx` now treats post-mount `weather` changes as the only transition trigger
+- First render does not create an overlay
+- Each change keeps only one previous-weather overlay, resets the transition token on rapid switch, and clears after the fade window closes
+- Scene test hooks now expose `data-transition-active`, `data-last-transition-from`, `data-last-transition-to`, `data-last-transition-token`, `data-last-transition-mounted-token`, and `data-last-transition-cleared-token`
+
+## Motion + Layering
+- Fade duration is `WEATHER_TRANSITION_MS = 320`
+- Overlay cleanup runs after `320ms + 40ms` guard time
+- Overlay lives inside `farm-v2-scene`, above `FarmBackdropV2`, below HUD / board, and remains `pointer-events-none`
+- Previous-weather visuals reuse `FarmBackdropV2` under a dedicated `farm-v2-weather-transition-overlay` test id
+
+## Code Entry
+- `src/components/farm-v2/FarmPlotBoardV2.tsx`
+- `e2e/farm-weather-transition.spec.ts`
+- `e2e/farm-weather-badge.spec.ts`
+- `e2e/farm-weather-visuals.spec.ts`
+
+## Verification
+- `npm run build`
+- `npx playwright test e2e/farm-weather-transition.spec.ts --project=desktop --timeout=60000`
+- `npx playwright test e2e/farm-weather-transition.spec.ts --project=mobile --timeout=60000`
+- `npx playwright test e2e/farm-weather-badge.spec.ts e2e/farm-weather-visuals.spec.ts --project=desktop --timeout=60000`
+- `npx playwright test e2e/farm-weather-badge.spec.ts e2e/farm-weather-visuals.spec.ts --project=mobile --timeout=60000`
+
+## Desktop Acceptance
+- Debug `切换天气` and `清除天气` both drive the same scene transition metadata and overlay lifecycle
+- Rapid switch keeps a single transition token instead of stacking overlays
+- Plot click still opens the seed modal while a transition is active, so the overlay does not intercept interaction
+- Real production weather rotation also emits the same transition metadata and lands on the expected next weather scene
+
+## Mobile Acceptance
+- After rainy and rainbow transitions settle, weather decor still stays above the first row of plots
+- Badge remains above the board and the board keeps its original interaction area
+- Existing weather split proof still differentiates sunny / cloudy / rainy / night / rainbow on mobile without pushing the board down
+
+## Notes
+- `farm-v2-weather-transition-overlay` keeps backdrop-only visuals, so plot tiles and HUD stay untouched during fade
+- Backdrop test ids now support a transition-specific prefix to avoid duplicate selector collisions during proof runs
+- Weather badge / visuals suites now use the current farm-entry locator and a larger per-suite timeout budget for screenshot-based proof runs

--- a/e2e/farm-weather-badge.spec.ts
+++ b/e2e/farm-weather-badge.spec.ts
@@ -107,7 +107,7 @@ function seedInit(page: Page, state: SeedState) {
 
 async function goToFarm(page: Page) {
   await page.goto('/');
-  await page.locator('header button').filter({ hasText: '🌱' }).first().click();
+  await page.getByRole('button', { name: /(Farm|农场|🌱)/ }).first().click();
   await expect(page.locator('[data-testid="farm-v2-weather-badge"]')).toBeVisible();
 }
 
@@ -119,6 +119,7 @@ async function captureProof(page: Page, testInfo: TestInfo, name: string) {
 }
 
 test.describe('Farm weather badge', () => {
+  test.describe.configure({ timeout: 60000 });
   test('desktop badge stays in sync with weather updates and uses zh weather names', async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== 'desktop', 'desktop proof only');
     await seedInit(page, createSeedState({ language: 'zh', weather: 'sunny', debugMode: true }));

--- a/e2e/farm-weather-transition.spec.ts
+++ b/e2e/farm-weather-transition.spec.ts
@@ -1,0 +1,246 @@
+import { expect, test, type Locator, type Page, type TestInfo } from '@playwright/test';
+import type { Plot, Weather, WeatherState } from '../src/types/farm';
+import { WEATHER_SWITCH_INTERVAL_MS } from '../src/utils/weather';
+
+interface SeedState {
+  settings: Record<string, unknown>;
+  farm: Record<string, unknown>;
+  shed: Record<string, unknown>;
+  gene: Record<string, unknown>;
+  weatherState: WeatherState;
+  debugWeatherOverride?: Weather | null;
+  debugMode?: boolean;
+}
+
+function getTodayKey(now: number = Date.now()): string {
+  const date = new Date(now);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+function createEmptyPlot(id: number): Plot {
+  return {
+    id,
+    state: 'empty',
+    progress: 0,
+    mutationStatus: 'none',
+    mutationChance: 0.02,
+    isMutant: false,
+    accumulatedMinutes: 0,
+    lastActivityTimestamp: 0,
+    hasTracker: false,
+  };
+}
+
+function createSeedState(options?: {
+  language?: 'zh' | 'en';
+  weather?: Weather;
+  lastChangeAt?: number;
+  debugWeatherOverride?: Weather | null;
+  debugMode?: boolean;
+  normalSeeds?: number;
+}): SeedState {
+  const now = Date.now();
+
+  return {
+    settings: {
+      workMinutes: 25,
+      shortBreakMinutes: 5,
+      theme: 'dark',
+      language: options?.language ?? 'zh',
+    },
+    farm: {
+      plots: Array.from({ length: 4 }, (_, index) => createEmptyPlot(index)),
+      collection: [],
+      lastActiveDate: getTodayKey(now),
+      consecutiveInactiveDays: 0,
+      lastActivityTimestamp: now,
+      guardianBarrierDate: '',
+      stolenRecords: [],
+    },
+    shed: {
+      seeds: { normal: options?.normalSeeds ?? 0, epic: 0, legendary: 0 },
+      items: {},
+      totalSliced: 0,
+      pity: { epicPity: 0, legendaryPity: 0 },
+      injectedSeeds: [],
+      hybridSeeds: [],
+      prismaticSeeds: [],
+      darkMatterSeeds: [],
+    },
+    gene: {
+      fragments: [],
+    },
+    weatherState: {
+      current: options?.weather ?? 'sunny',
+      lastChangeAt: options?.lastChangeAt ?? now,
+    },
+    debugWeatherOverride: options?.debugWeatherOverride,
+    debugMode: options?.debugMode ?? false,
+  };
+}
+
+function seedInit(page: Page, state: SeedState) {
+  return page.addInitScript((payload: SeedState) => {
+    localStorage.clear();
+    localStorage.setItem('pomodoro-guide-seen', '1');
+    localStorage.setItem('pomodoro-settings', JSON.stringify(payload.settings));
+    localStorage.setItem('watermelon-farm', JSON.stringify(payload.farm));
+    localStorage.setItem('watermelon-shed', JSON.stringify(payload.shed));
+    localStorage.setItem('watermelon-genes', JSON.stringify(payload.gene));
+    localStorage.setItem('weatherState', JSON.stringify(payload.weatherState));
+
+    if (payload.debugWeatherOverride !== undefined) {
+      localStorage.setItem('weatherDebugOverride', JSON.stringify(payload.debugWeatherOverride));
+    } else {
+      localStorage.removeItem('weatherDebugOverride');
+    }
+
+    if (payload.debugMode) {
+      localStorage.setItem('watermelon-debug', 'true');
+    } else {
+      localStorage.removeItem('watermelon-debug');
+    }
+  }, state);
+}
+
+async function goToFarm(page: Page) {
+  await page.goto('/');
+  await page.getByRole('button', { name: /(Farm|农场|🌱)/ }).first().click();
+  await expect(page.locator('[data-testid="farm-v2-scene"]')).toBeVisible();
+  await expect(page.locator('[data-testid="farm-plot-board-v2"]')).toBeVisible();
+}
+
+function scene(page: Page): Locator {
+  return page.locator('[data-testid="farm-v2-scene"]');
+}
+
+function overlay(page: Page): Locator {
+  return page.locator('[data-testid="farm-v2-weather-transition-overlay"]');
+}
+
+async function expectOverlay(page: Page, fromWeather: Weather, toWeather: Weather): Promise<string> {
+  const farmScene = scene(page);
+
+  await expect.poll(async () => farmScene.getAttribute('data-last-transition-from'), { timeout: 3000 }).toBe(fromWeather);
+  await expect.poll(async () => farmScene.getAttribute('data-last-transition-to'), { timeout: 3000 }).toBe(toWeather);
+  await expect.poll(async () => {
+    const token = await farmScene.getAttribute('data-last-transition-token');
+    const mountedToken = await farmScene.getAttribute('data-last-transition-mounted-token');
+    return token && token === mountedToken ? token : '';
+  }, { timeout: 3000 }).not.toBe('');
+
+  const transitionToken = await farmScene.getAttribute('data-last-transition-token');
+  expect(transitionToken).not.toBeNull();
+  return transitionToken ?? '0';
+}
+
+async function waitForOverlayToClear(page: Page, transitionToken: string) {
+  const farmScene = scene(page);
+  await expect.poll(async () => farmScene.getAttribute('data-last-transition-cleared-token'), { timeout: 3000 }).toBe(transitionToken);
+  await expect.poll(async () => farmScene.getAttribute('data-transition-active'), { timeout: 3000 }).toBe('false');
+  await expect.poll(async () => overlay(page).count(), { timeout: 3000 }).toBe(0);
+}
+
+async function captureProof(page: Page, testInfo: TestInfo, name: string) {
+  await page.screenshot({
+    path: testInfo.outputPath(name),
+    fullPage: false,
+  });
+}
+
+async function getBottomBounds(page: Page, selector: string): Promise<number[]> {
+  const locator = page.locator(selector);
+  const count = await locator.count();
+  const bottoms: number[] = [];
+
+  for (let index = 0; index < count; index += 1) {
+    const box = await locator.nth(index).boundingBox();
+    if (box) {
+      bottoms.push(box.y + box.height);
+    }
+  }
+
+  return bottoms;
+}
+
+test.describe('Farm V2 weather transitions', () => {
+  test.describe.configure({ timeout: 60000 });
+  test('desktop debug path reuses one overlay, clears cleanly, and never blocks plot clicks', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'desktop proof only');
+
+    await seedInit(page, createSeedState({ weather: 'sunny', debugMode: true, normalSeeds: 1 }));
+    await goToFarm(page);
+
+    await expect(scene(page)).toHaveAttribute('data-transition-active', 'false');
+
+    await page.getByRole('button', { name: '切换天气' }).click();
+    await expectOverlay(page, 'sunny', 'cloudy');
+    await captureProof(page, testInfo, 'desktop-transition-debug-cloudy.png');
+
+    await page.getByRole('button', { name: '切换天气' }).click();
+    const rainyTransitionToken = await expectOverlay(page, 'cloudy', 'rainy');
+
+    await page.locator('[data-testid="farm-plot-board-v2"] [role="button"]').first().click();
+    await expect(page.getByRole('heading', { name: '选择种子' })).toBeVisible();
+    await page.getByRole('button', { name: '取消' }).click();
+
+    await waitForOverlayToClear(page, rainyTransitionToken);
+
+    await page.getByRole('button', { name: '清除天气' }).click();
+    const clearTransitionToken = await expectOverlay(page, 'rainy', 'sunny');
+    await waitForOverlayToClear(page, clearTransitionToken);
+    await expect.poll(async () => page.evaluate(() => JSON.parse(localStorage.getItem('weatherDebugOverride') ?? 'null'))).toBe(null);
+  });
+
+  test('desktop real weather rotation uses the same scene overlay trigger', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'desktop proof only');
+
+    await page.addInitScript(() => {
+      Math.random = () => 0.5;
+    });
+    await seedInit(page, createSeedState({
+      weather: 'sunny',
+      lastChangeAt: Date.now() - WEATHER_SWITCH_INTERVAL_MS + 700,
+      normalSeeds: 1,
+    }));
+    await goToFarm(page);
+
+    const realTransitionToken = await expectOverlay(page, 'sunny', 'cloudy');
+    await captureProof(page, testInfo, 'desktop-transition-real-rotation.png');
+    await waitForOverlayToClear(page, realTransitionToken);
+    await expect(scene(page)).toHaveAttribute('data-current-weather', 'cloudy');
+  });
+
+  test('mobile rainy and rainbow decor stay above the board after transitions settle', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile', 'mobile proof only');
+
+    await seedInit(page, createSeedState({ weather: 'cloudy', debugMode: true }));
+    await goToFarm(page);
+
+    await page.getByRole('button', { name: '切换天气' }).click();
+    const rainyTransitionToken = await expectOverlay(page, 'cloudy', 'rainy');
+    await waitForOverlayToClear(page, rainyTransitionToken);
+    await captureProof(page, testInfo, 'mobile-transition-rainy.png');
+
+    const rainyBoardBox = await page.locator('[data-testid="farm-plot-board-v2"]').boundingBox();
+    expect(rainyBoardBox).not.toBeNull();
+    const rainyBottoms = await getBottomBounds(page, '[data-testid="farm-v2-rain-layer"]');
+    expect(rainyBottoms.length).toBeGreaterThan(0);
+    expect(Math.max(...rainyBottoms)).toBeLessThan(rainyBoardBox?.y ?? Number.POSITIVE_INFINITY);
+
+    await page.getByRole('button', { name: '切换天气' }).click();
+    const nightTransitionToken = await expectOverlay(page, 'rainy', 'night');
+    await waitForOverlayToClear(page, nightTransitionToken);
+
+    await page.getByRole('button', { name: '切换天气' }).click();
+    const rainbowTransitionToken = await expectOverlay(page, 'night', 'rainbow');
+    await waitForOverlayToClear(page, rainbowTransitionToken);
+    await captureProof(page, testInfo, 'mobile-transition-rainbow.png');
+
+    const rainbowBoardBox = await page.locator('[data-testid="farm-plot-board-v2"]').boundingBox();
+    expect(rainbowBoardBox).not.toBeNull();
+    const rainbowBottoms = await getBottomBounds(page, '[data-testid="farm-v2-rainbow"]');
+    expect(rainbowBottoms).toHaveLength(1);
+    expect(rainbowBottoms[0]).toBeLessThan(rainbowBoardBox?.y ?? Number.POSITIVE_INFINITY);
+  });
+});

--- a/e2e/farm-weather-visuals.spec.ts
+++ b/e2e/farm-weather-visuals.spec.ts
@@ -93,7 +93,7 @@ function seedInit(page: Page, state: SeedState) {
 
 async function goToFarm(page: Page) {
   await page.goto('/');
-  await page.locator('header button').filter({ hasText: '🌱' }).first().click();
+  await page.getByRole('button', { name: /(Farm|农场|🌱)/ }).first().click();
   await expect(page.locator('[data-testid="farm-v2-scene"]')).toBeVisible();
   await expect(page.locator('[data-testid="farm-plot-board-v2"]')).toBeVisible();
 }
@@ -145,6 +145,7 @@ async function getBottomBounds(page: Page, selector: string): Promise<number[]> 
 }
 
 test.describe('Farm V2 weather visuals', () => {
+  test.describe.configure({ timeout: 60000 });
   test('desktop proof differentiates five weather states without touching the interaction layout', async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== 'desktop', 'desktop proof only');
 

--- a/src/components/farm-v2/FarmPlotBoardV2.tsx
+++ b/src/components/farm-v2/FarmPlotBoardV2.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Plot, Weather } from '../../types/farm';
 import { WEATHER_ICON_MAP } from '../../utils/weather';
 import { FarmPlotTileV2 } from './FarmPlotTileV2';
@@ -92,6 +92,17 @@ interface WeatherBackdropVisuals {
 const GRID_SIDE = 3;
 const TOTAL_PLOTS = GRID_SIDE * GRID_SIDE;
 const MOTION_CLASS = 'farm-v2-motion';
+const WEATHER_TRANSITION_MS = 320;
+
+interface WeatherTransitionOverlayState {
+  previousWeather: Weather;
+  nextWeather: Weather;
+  token: number;
+}
+
+function getBackdropTestId(prefix: string, suffix: string) {
+  return `${prefix}-${suffix}`;
+}
 
 const SUNNY_CLOUDS: CloudSpec[] = [
   { top: '3%', left: '6%', width: '22%', height: '10%', opacity: 0.74, duration: '13s', delay: '-0.8s', filter: 'saturate(1.04) brightness(1.04)' },
@@ -389,10 +400,11 @@ function CloudCluster({
   delay,
   filter,
   zIndex,
-}: CloudSpec) {
+  testId,
+}: CloudSpec & { testId?: string }) {
   return (
     <div
-      data-testid="farm-v2-cloud-cluster"
+      data-testid={testId}
       className={`absolute ${MOTION_CLASS}`}
       style={{
         top,
@@ -418,10 +430,12 @@ function RainLayer({
   spec,
   compactMode,
   useTightBackdrop,
+  testId,
 }: {
   spec: RainLayerSpec;
   compactMode: boolean;
   useTightBackdrop: boolean;
+  testId?: string;
 }) {
   const top = compactMode
     ? spec.topCompact ?? spec.top
@@ -446,7 +460,7 @@ function RainLayer({
 
   return (
     <div
-      data-testid="farm-v2-rain-layer"
+      data-testid={testId}
       className="absolute z-[7] overflow-hidden"
       style={{
         top,
@@ -482,10 +496,12 @@ function RainbowArc({
   spec,
   compactMode,
   useTightBackdrop,
+  testId,
 }: {
   spec: RainbowSpec;
   compactMode: boolean;
   useTightBackdrop: boolean;
+  testId?: string;
 }) {
   const top = compactMode
     ? spec.topCompact ?? spec.top
@@ -511,7 +527,7 @@ function RainbowArc({
 
   return (
     <div
-      data-testid="farm-v2-rainbow"
+      data-testid={testId}
       className="absolute z-[6] overflow-hidden"
       style={{
         top,
@@ -653,7 +669,15 @@ function Cottage({ left, top }: { left: string; top: string }) {
   );
 }
 
-function FarmBackdropV2({ compactMode, weather }: { compactMode: boolean; weather: Weather }) {
+function FarmBackdropV2({
+  compactMode,
+  weather,
+  testIdPrefix = 'farm-v2',
+}: {
+  compactMode: boolean;
+  weather: Weather;
+  testIdPrefix?: string;
+}) {
   const isNarrowScreen = typeof window !== 'undefined' && window.innerWidth < 640;
   const useCompactMobilePolish = isNarrowScreen && compactMode;
   const useTightBackdrop = isNarrowScreen && !compactMode;
@@ -686,7 +710,7 @@ function FarmBackdropV2({ compactMode, weather }: { compactMode: boolean; weathe
   return (
     <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden">
       <div
-        data-testid="farm-v2-sky-layer"
+        data-testid={getBackdropTestId(testIdPrefix, 'sky-layer')}
         className="absolute inset-x-0 top-0 z-[1]"
         style={{
           height: skyHeight,
@@ -784,11 +808,12 @@ function FarmBackdropV2({ compactMode, weather }: { compactMode: boolean; weathe
           spec={visuals.rainbow}
           compactMode={compactMode}
           useTightBackdrop={useTightBackdrop || useCompactMobilePolish}
+          testId={getBackdropTestId(testIdPrefix, 'rainbow')}
         />
       )}
 
       <div
-        data-testid="farm-v2-celestial-halo"
+        data-testid={getBackdropTestId(testIdPrefix, 'celestial-halo')}
         className={`absolute z-[6] rounded-full ${MOTION_CLASS}`}
         style={{
           top: compactMode ? '5%' : '4.5%',
@@ -802,7 +827,7 @@ function FarmBackdropV2({ compactMode, weather }: { compactMode: boolean; weathe
       />
       <div
         className={`absolute ${isNight ? 'z-[9]' : 'z-[7]'} rounded-full ${MOTION_CLASS}`}
-        data-testid="farm-v2-celestial-body"
+        data-testid={getBackdropTestId(testIdPrefix, 'celestial-body')}
         aria-label={isNight ? 'moon' : 'sun'}
         style={{
           top: compactMode ? (isNight ? '7.4%' : '7.2%') : (isNight ? '7%' : '6.8%'),
@@ -842,7 +867,11 @@ function FarmBackdropV2({ compactMode, weather }: { compactMode: boolean; weathe
       </div>
 
       {visuals.cloudSpecs.map((cloud, index) => (
-        <CloudCluster key={`farm-v2-cloud-${weather}-${index}`} {...cloud} />
+        <CloudCluster
+          key={`farm-v2-cloud-${weather}-${index}`}
+          {...cloud}
+          testId={getBackdropTestId(testIdPrefix, 'cloud-cluster')}
+        />
       ))}
       {visuals.rainLayers.map((spec, index) => (
         <RainLayer
@@ -850,6 +879,7 @@ function FarmBackdropV2({ compactMode, weather }: { compactMode: boolean; weathe
           spec={spec}
           compactMode={compactMode}
           useTightBackdrop={useTightBackdrop || useCompactMobilePolish}
+          testId={getBackdropTestId(testIdPrefix, 'rain-layer')}
         />
       ))}
 
@@ -960,6 +990,50 @@ function FarmBackdropV2({ compactMode, weather }: { compactMode: boolean; weathe
   );
 }
 
+function FarmWeatherTransitionOverlay({
+  compactMode,
+  previousWeather,
+  nextWeather,
+  token,
+}: {
+  compactMode: boolean;
+  previousWeather: Weather;
+  nextWeather: Weather;
+  token: number;
+}) {
+  const previousVisuals = getWeatherBackdropVisuals(previousWeather);
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const frameId = window.requestAnimationFrame(() => {
+      setIsVisible(false);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, []);
+
+  return (
+    <div
+      data-testid="farm-v2-weather-transition-overlay"
+      data-from-weather={previousWeather}
+      data-to-weather={nextWeather}
+      data-transition-token={String(token)}
+      data-transition-ms={String(WEATHER_TRANSITION_MS)}
+      className="pointer-events-none absolute inset-0 z-[12] overflow-hidden"
+      style={{
+        background: previousVisuals.sceneBackground,
+        opacity: isVisible ? 1 : 0,
+        transition: `opacity ${WEATHER_TRANSITION_MS}ms ease-out`,
+        willChange: 'opacity',
+      }}
+    >
+      <FarmBackdropV2 compactMode={compactMode} weather={previousWeather} testIdPrefix="farm-v2-transition" />
+    </div>
+  );
+}
+
 function FarmBoardSceneDecorV2({
   compactMode,
   useTightMobileSpacing,
@@ -995,6 +1069,14 @@ export function FarmPlotBoardV2({
   harvestablePlotCount,
   onPlotClick,
 }: FarmPlotBoardV2Props) {
+  const previousWeatherRef = useRef(weather);
+  const hasMountedRef = useRef(false);
+  const transitionTokenRef = useRef(0);
+  const activeTransitionTokenRef = useRef(0);
+  const [transitionOverlay, setTransitionOverlay] = useState<WeatherTransitionOverlayState | null>(null);
+  const [lastTransitionMeta, setLastTransitionMeta] = useState<WeatherTransitionOverlayState | null>(null);
+  const [mountedTransitionToken, setMountedTransitionToken] = useState(0);
+  const [clearedTransitionToken, setClearedTransitionToken] = useState(0);
   const displaySlots = useMemo(
     () => Array.from({ length: TOTAL_PLOTS }, (_, index) => ({
       plot: plots[index] ?? null,
@@ -1039,9 +1121,61 @@ export function FarmPlotBoardV2({
   const hudWeatherBadgeOffset = useTightMobileSpacing ? 42 : compactMode ? 38 : 34;
   const backdropVisuals = getWeatherBackdropVisuals(weather);
 
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      previousWeatherRef.current = weather;
+      return;
+    }
+
+    if (previousWeatherRef.current === weather) {
+      return;
+    }
+
+    transitionTokenRef.current += 1;
+    const nextTransition = {
+      previousWeather: previousWeatherRef.current,
+      nextWeather: weather,
+      token: transitionTokenRef.current,
+    };
+    setTransitionOverlay(nextTransition);
+    setLastTransitionMeta(nextTransition);
+    setMountedTransitionToken(nextTransition.token);
+    activeTransitionTokenRef.current = nextTransition.token;
+    previousWeatherRef.current = weather;
+  }, [weather]);
+
+  useEffect(() => {
+    if (!transitionOverlay) {
+      return;
+    }
+
+    const transitionToken = transitionOverlay.token;
+    const timeoutId = window.setTimeout(() => {
+      if (activeTransitionTokenRef.current !== transitionToken) {
+        return;
+      }
+
+      activeTransitionTokenRef.current = 0;
+      setTransitionOverlay(null);
+      setClearedTransitionToken(transitionToken);
+    }, WEATHER_TRANSITION_MS + 40);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [transitionOverlay]);
+
   return (
     <div
       data-testid="farm-v2-scene"
+      data-current-weather={weather}
+      data-transition-active={transitionOverlay ? 'true' : 'false'}
+      data-last-transition-from={lastTransitionMeta?.previousWeather ?? ''}
+      data-last-transition-to={lastTransitionMeta?.nextWeather ?? ''}
+      data-last-transition-token={lastTransitionMeta ? String(lastTransitionMeta.token) : '0'}
+      data-last-transition-mounted-token={String(mountedTransitionToken)}
+      data-last-transition-cleared-token={String(clearedTransitionToken)}
       className="relative w-full overflow-hidden"
       style={{
         minHeight: sceneMinHeight,
@@ -1050,6 +1184,15 @@ export function FarmPlotBoardV2({
       }}
     >
       <FarmBackdropV2 compactMode={compactMode} weather={weather} />
+      {transitionOverlay && (
+        <FarmWeatherTransitionOverlay
+          key={transitionOverlay.token}
+          compactMode={compactMode}
+          previousWeather={transitionOverlay.previousWeather}
+          nextWeather={transitionOverlay.nextWeather}
+          token={transitionOverlay.token}
+        />
+      )}
       <FarmHudV2
         compactMode={compactMode}
         weather={weather}


### PR DESCRIPTION
## Summary
- add a scene-level previous-weather overlay in `FarmPlotBoardV2`, keyed only by post-mount `weather` prop changes
- expose transition lifecycle proof hooks and add a dedicated weather-transition Playwright proof
- update weather badge and weather visuals proof suites to use the current farm entry locator and a 60s proof timeout budget

## Testing
- npm run build
- npx playwright test e2e/farm-weather-transition.spec.ts --project=desktop --timeout=60000
- npx playwright test e2e/farm-weather-transition.spec.ts --project=mobile --timeout=60000
- npx playwright test e2e/farm-weather-badge.spec.ts e2e/farm-weather-visuals.spec.ts --project=desktop --timeout=60000
- npx playwright test e2e/farm-weather-badge.spec.ts e2e/farm-weather-visuals.spec.ts --project=mobile --timeout=60000
