### PR TITLE
fix: follow up tight mobile farm scene spacing

### DIFF
--- a/artifacts/issue-134/proof-capture-address-bar.mjs
+++ b/artifacts/issue-134/proof-capture-address-bar.mjs
@@ -103,6 +103,10 @@ function createSeedState() {
       current: 'sunny',
       lastChangeAt: now,
     },
+    alienVisit: {
+      lastMelonAlienCheckDate: getTodayKey(now),
+      current: null,
+    },
   };
 }
 
@@ -116,6 +120,7 @@ async function seedInit(page) {
     localStorage.setItem('watermelon-shed', JSON.stringify(payload.shed));
     localStorage.setItem('watermelon-genes', JSON.stringify(payload.gene));
     localStorage.setItem('weatherState', JSON.stringify(payload.weatherState));
+    localStorage.setItem('alienVisit', JSON.stringify(payload.alienVisit));
     localStorage.removeItem('weatherDebugOverride');
     localStorage.removeItem('watermelon-debug');
   }, state);

--- a/artifacts/issue-134/proof-capture-address-bar.mjs
+++ b/artifacts/issue-134/proof-capture-address-bar.mjs
@@ -1,0 +1,212 @@
+import { chromium } from '@playwright/test';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const baseURL = process.env.BASE_URL ?? 'http://127.0.0.1:4273';
+const outDir = process.argv[2] ?? 'artifacts/issue-134/proof-address-bar';
+
+const viewports = [
+  { name: '390x844', width: 390, height: 844, visibleHeight: 760, isMobile: true, deviceScaleFactor: 3 },
+  { name: '360x800', width: 360, height: 800, visibleHeight: 716, isMobile: true, deviceScaleFactor: 3 },
+  { name: '1440x900', width: 1440, height: 900, visibleHeight: 900, isMobile: false, deviceScaleFactor: 1 },
+];
+
+function getTodayKey(now = Date.now()) {
+  const date = new Date(now);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+function createPlot(id, state) {
+  if (state === 'growing') {
+    return {
+      id,
+      state: 'growing',
+      seedQuality: 'normal',
+      varietyId: 'jade-stripe',
+      progress: 0.42,
+      accumulatedMinutes: 4200,
+      mutationStatus: 'none',
+      mutationChance: 0.02,
+      isMutant: false,
+      lastActivityTimestamp: Date.now(),
+      plantedDate: getTodayKey(),
+      lastUpdateDate: getTodayKey(),
+      hasTracker: false,
+    };
+  }
+
+  if (state === 'mature') {
+    return {
+      id,
+      state: 'mature',
+      seedQuality: 'normal',
+      varietyId: 'jade-stripe',
+      progress: 1,
+      accumulatedMinutes: 12000,
+      mutationStatus: 'none',
+      mutationChance: 0.02,
+      isMutant: false,
+      lastActivityTimestamp: Date.now(),
+      plantedDate: getTodayKey(),
+      lastUpdateDate: getTodayKey(),
+      hasTracker: false,
+    };
+  }
+
+  return {
+    id,
+    state: 'empty',
+    progress: 0,
+    mutationStatus: 'none',
+    mutationChance: 0.02,
+    isMutant: false,
+    accumulatedMinutes: 0,
+    lastActivityTimestamp: 0,
+    hasTracker: false,
+  };
+}
+
+function createSeedState() {
+  const now = Date.now();
+  const states = ['empty', 'growing', 'mature', 'empty', 'growing', 'mature', 'empty', 'growing', 'mature'];
+
+  return {
+    settings: {
+      workMinutes: 25,
+      shortBreakMinutes: 5,
+      theme: 'dark',
+      language: 'zh',
+    },
+    farm: {
+      plots: states.map((state, index) => createPlot(index, state)),
+      collection: ['jade-stripe'],
+      lastActiveDate: getTodayKey(now),
+      consecutiveInactiveDays: 0,
+      lastActivityTimestamp: now,
+      guardianBarrierDate: '',
+      stolenRecords: [],
+    },
+    shed: {
+      seeds: { normal: 9, epic: 0, legendary: 0 },
+      items: {},
+      totalSliced: 0,
+      pity: { epicPity: 0, legendaryPity: 0 },
+      injectedSeeds: [],
+      hybridSeeds: [],
+      prismaticSeeds: [],
+      darkMatterSeeds: [],
+    },
+    gene: {
+      fragments: [],
+    },
+    weatherState: {
+      current: 'sunny',
+      lastChangeAt: now,
+    },
+  };
+}
+
+async function seedInit(page) {
+  const state = createSeedState();
+  await page.addInitScript((payload) => {
+    localStorage.clear();
+    localStorage.setItem('pomodoro-guide-seen', '1');
+    localStorage.setItem('pomodoro-settings', JSON.stringify(payload.settings));
+    localStorage.setItem('watermelon-farm', JSON.stringify(payload.farm));
+    localStorage.setItem('watermelon-shed', JSON.stringify(payload.shed));
+    localStorage.setItem('watermelon-genes', JSON.stringify(payload.gene));
+    localStorage.setItem('weatherState', JSON.stringify(payload.weatherState));
+    localStorage.removeItem('weatherDebugOverride');
+    localStorage.removeItem('watermelon-debug');
+  }, state);
+}
+
+async function overrideVisualViewport(page, viewport) {
+  if (!viewport.isMobile) return;
+  await page.addInitScript(({ width, visibleHeight }) => {
+    const listeners = { resize: new Set(), scroll: new Set() };
+    const fakeVisualViewport = {
+      width,
+      height: visibleHeight,
+      scale: 1,
+      offsetLeft: 0,
+      offsetTop: 0,
+      pageLeft: 0,
+      pageTop: 0,
+      addEventListener(type, callback) {
+        listeners[type]?.add(callback);
+      },
+      removeEventListener(type, callback) {
+        listeners[type]?.delete(callback);
+      },
+      dispatchEvent() {
+        return true;
+      },
+    };
+
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+  }, { width: viewport.width, visibleHeight: viewport.visibleHeight });
+}
+
+async function goToFarm(page) {
+  await page.goto(baseURL);
+  await page.getByRole('button', { name: /(Farm|农场|🌱)/ }).first().click();
+  await page.locator('[data-testid="farm-v2-scene"]').waitFor();
+}
+
+async function captureMetrics(page) {
+  return page.evaluate(() => {
+    const board = document.querySelector('[data-testid="farm-plot-board-v2"]');
+    const scene = document.querySelector('[data-testid="farm-v2-scene"]');
+    const weatherBadge = document.querySelector('[data-testid="farm-v2-weather-badge"]');
+    const fence = document.querySelector('[data-testid="farm-v2-fence"]');
+    const tiles = Array.from(document.querySelectorAll('[data-testid="farm-plot-board-v2"] [data-slot-state]'));
+    const lastRow = tiles.slice(-3).map((tile) => tile.getBoundingClientRect());
+    const visualViewportHeight = window.visualViewport?.height ?? window.innerHeight;
+
+    return {
+      innerWidth: window.innerWidth,
+      innerHeight: window.innerHeight,
+      visualViewportHeight,
+      scrollWidth: document.documentElement.scrollWidth,
+      scrollHeight: document.documentElement.scrollHeight,
+      sceneRect: scene?.getBoundingClientRect() ?? null,
+      boardRect: board?.getBoundingClientRect() ?? null,
+      weatherBadgeRect: weatherBadge?.getBoundingClientRect() ?? null,
+      fenceRect: fence?.getBoundingClientRect() ?? null,
+      lastRow,
+      lastRowVisibleBottomGap: lastRow.length > 0 ? visualViewportHeight - Math.max(...lastRow.map((tile) => tile.bottom)) : null,
+      sceneVisibleBottomGap: scene ? visualViewportHeight - scene.getBoundingClientRect().bottom : null,
+      hasHorizontalOverflow: document.documentElement.scrollWidth > window.innerWidth,
+    };
+  });
+}
+
+await fs.mkdir(outDir, { recursive: true });
+const browser = await chromium.launch({ headless: true });
+
+try {
+  for (const viewport of viewports) {
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+      isMobile: viewport.isMobile,
+      hasTouch: viewport.isMobile,
+      deviceScaleFactor: viewport.deviceScaleFactor,
+    });
+    const page = await context.newPage();
+    await overrideVisualViewport(page, viewport);
+    await seedInit(page);
+    await goToFarm(page);
+
+    const metrics = await captureMetrics(page);
+    const baseName = `farm-${viewport.name}-address-bar-expanded`;
+    await page.screenshot({ path: path.join(outDir, `${baseName}.png`), fullPage: true });
+    await fs.writeFile(path.join(outDir, `${baseName}.json`), JSON.stringify({ metrics }, null, 2));
+    await context.close();
+  }
+} finally {
+  await browser.close();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pomodoro",
-  "version": "0.61.21",
+  "version": "0.61.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pomodoro",
-      "version": "0.61.21",
+      "version": "0.61.22",
       "dependencies": {
         "@capacitor/android": "^8.1.0",
         "@capacitor/cli": "^8.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pomodoro",
-  "version": "0.61.20",
+  "version": "0.61.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pomodoro",
-      "version": "0.61.20",
+      "version": "0.61.21",
       "dependencies": {
         "@capacitor/android": "^8.1.0",
         "@capacitor/cli": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pomodoro",
   "private": true,
-  "version": "0.61.20",
+  "version": "0.61.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pomodoro",
   "private": true,
-  "version": "0.61.21",
+  "version": "0.61.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/FarmPage.tsx
+++ b/src/components/FarmPage.tsx
@@ -459,7 +459,7 @@ export function FarmPage({
 
   return (
     <div
-      className={`flex-1 flex flex-col w-full ${compactShell ? 'px-0 pt-0 pb-0 gap-0' : useTightMobileFarmShell ? 'px-2.5 sm:px-4 pt-1 pb-2 gap-1.5' : gentleV2Layout ? 'px-3 sm:px-4 pt-2 pb-3 gap-2' : 'px-4 pt-4 pb-6 gap-4'}`}
+      className={`flex-1 flex flex-col w-full ${compactShell ? 'px-0 pt-0 pb-0 gap-0' : useTightMobileFarmShell ? 'px-2 sm:px-4 pt-0.5 pb-1.5 gap-1' : gentleV2Layout ? 'px-3 sm:px-4 pt-2 pb-3 gap-2' : 'px-4 pt-4 pb-6 gap-4'}`}
       style={gentleV2Layout
         ? {
           background: 'linear-gradient(180deg, #9ad7f4 0%, #a6def2 28%, #a8d993 56%, #94cf73 100%)',
@@ -472,7 +472,7 @@ export function FarmPage({
           <SubTabHeader subTab={subTab} setSubTab={setSubTab} theme={theme} t={t} gentle={useFarmPlotBoardV2} />
 
           {/* 道具快捷栏 */}
-          <div className={`flex items-center overflow-x-auto no-scrollbar ${useTightMobileFarmShell ? 'gap-1.5 pb-0.5' : 'gap-2 pb-1'}`}>
+          <div className={`flex items-center overflow-x-auto no-scrollbar ${useTightMobileFarmShell ? 'gap-1 pb-0' : 'gap-2 pb-1'}`}>
             {(lullabyCount > 0 || lullabyActive) && (
               <button
                 type="button"
@@ -657,7 +657,7 @@ export function FarmPage({
 
       {/* 农场场景 */}
       <div
-        className={`farm-page relative isolate min-h-0 ${useFarmPlotBoardV2 && !compactShell ? 'flex-none -mx-2.5 sm:mx-0 sm:flex-1' : 'flex-1'} ${compactShell ? 'pt-0' : useTightMobileFarmShell ? 'pt-0.5' : gentleV2Layout ? 'pt-1' : 'pt-4'}`}
+        className={`farm-page relative isolate min-h-0 ${useFarmPlotBoardV2 && !compactShell ? 'flex-none -mx-2 sm:mx-0 sm:flex-1' : 'flex-1'} ${compactShell ? 'pt-0' : useTightMobileFarmShell ? 'pt-0' : gentleV2Layout ? 'pt-1' : 'pt-4'}`}
         style={compactShell
           ? {
             background: 'linear-gradient(180deg, #90d6f6 0%, #bdeafd 38%, #b4e8a6 58%, #9ad577 80%, #8cc764 100%)',

--- a/src/components/FarmPage.tsx
+++ b/src/components/FarmPage.tsx
@@ -206,6 +206,7 @@ export function FarmPage({
     return forcedBoard !== 'legacy';
   }, []);
   const gentleV2Layout = useFarmPlotBoardV2 && !compactShell;
+  const useTightMobileFarmShell = gentleV2Layout && typeof window !== 'undefined' && window.innerWidth < 640;
 
   // 追踪已揭晓的地块（避免重复触发动画）
   const revealedRef = useRef<Set<number>>(new Set());
@@ -458,7 +459,7 @@ export function FarmPage({
 
   return (
     <div
-      className={`flex-1 flex flex-col w-full ${compactShell ? 'px-0 pt-0 pb-0 gap-0' : gentleV2Layout ? 'px-3 sm:px-4 pt-2 pb-3 gap-2' : 'px-4 pt-4 pb-6 gap-4'}`}
+      className={`flex-1 flex flex-col w-full ${compactShell ? 'px-0 pt-0 pb-0 gap-0' : useTightMobileFarmShell ? 'px-2.5 sm:px-4 pt-1 pb-2 gap-1.5' : gentleV2Layout ? 'px-3 sm:px-4 pt-2 pb-3 gap-2' : 'px-4 pt-4 pb-6 gap-4'}`}
       style={gentleV2Layout
         ? {
           background: 'linear-gradient(180deg, #9ad7f4 0%, #a6def2 28%, #a8d993 56%, #94cf73 100%)',
@@ -471,7 +472,7 @@ export function FarmPage({
           <SubTabHeader subTab={subTab} setSubTab={setSubTab} theme={theme} t={t} gentle={useFarmPlotBoardV2} />
 
           {/* 道具快捷栏 */}
-          <div className="flex items-center gap-2 overflow-x-auto no-scrollbar pb-1">
+          <div className={`flex items-center overflow-x-auto no-scrollbar ${useTightMobileFarmShell ? 'gap-1.5 pb-0.5' : 'gap-2 pb-1'}`}>
             {(lullabyCount > 0 || lullabyActive) && (
               <button
                 type="button"
@@ -656,7 +657,7 @@ export function FarmPage({
 
       {/* 农场场景 */}
       <div
-        className={`farm-page relative isolate min-h-0 ${useFarmPlotBoardV2 && !compactShell ? 'flex-none -mx-3 sm:mx-0 sm:flex-1' : 'flex-1'} ${compactShell ? 'pt-0' : gentleV2Layout ? 'pt-1' : 'pt-4'}`}
+        className={`farm-page relative isolate min-h-0 ${useFarmPlotBoardV2 && !compactShell ? 'flex-none -mx-2.5 sm:mx-0 sm:flex-1' : 'flex-1'} ${compactShell ? 'pt-0' : useTightMobileFarmShell ? 'pt-0.5' : gentleV2Layout ? 'pt-1' : 'pt-4'}`}
         style={compactShell
           ? {
             background: 'linear-gradient(180deg, #90d6f6 0%, #bdeafd 38%, #b4e8a6 58%, #9ad577 80%, #8cc764 100%)',
@@ -974,6 +975,8 @@ function SubTabHeader({ subTab, setSubTab, theme, t, gentle = false }: {
 
   const activeTextColor = gentle ? '#5c371f' : theme.text;
   const inactiveTextColor = gentle ? 'rgba(90,60,37,0.75)' : theme.textMuted;
+  const useTightMobileTabs = gentle && typeof window !== 'undefined' && window.innerWidth < 640;
+  const tabButtonClass = `relative z-10 rounded-full font-semibold transition-all duration-200 ease-in-out cursor-pointer flex-1 ${useTightMobileTabs ? 'px-3 py-1.5 text-[11px]' : 'px-4 py-2 text-xs'}`;
 
   return (
     <div className="w-full">
@@ -989,7 +992,7 @@ function SubTabHeader({ subTab, setSubTab, theme, t, gentle = false }: {
         />
         <button
           onClick={() => setSubTab('plots')}
-          className="relative z-10 px-4 py-2 rounded-full text-xs font-semibold transition-all duration-200 ease-in-out cursor-pointer flex-1"
+          className={tabButtonClass}
           style={{
             color: subTab === 'plots' ? activeTextColor : inactiveTextColor,
           }}
@@ -998,7 +1001,7 @@ function SubTabHeader({ subTab, setSubTab, theme, t, gentle = false }: {
         </button>
         <button
           onClick={() => setSubTab('collection')}
-          className="relative z-10 px-4 py-2 rounded-full text-xs font-semibold transition-all duration-200 ease-in-out cursor-pointer flex-1"
+          className={tabButtonClass}
           style={{
             color: subTab === 'collection' ? activeTextColor : inactiveTextColor,
           }}
@@ -1007,7 +1010,7 @@ function SubTabHeader({ subTab, setSubTab, theme, t, gentle = false }: {
         </button>
         <button
           onClick={() => setSubTab('lab')}
-          className="relative z-10 px-4 py-2 rounded-full text-xs font-semibold transition-all duration-200 ease-in-out cursor-pointer flex-1"
+          className={tabButtonClass}
           style={{
             color: subTab === 'lab' ? activeTextColor : inactiveTextColor,
           }}

--- a/src/components/farm-v2/FarmPlotBoardV2.tsx
+++ b/src/components/farm-v2/FarmPlotBoardV2.tsx
@@ -104,6 +104,44 @@ function getBackdropTestId(prefix: string, suffix: string) {
   return `${prefix}-${suffix}`;
 }
 
+function clampNumber(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function getViewportHeightPx() {
+  if (typeof window === 'undefined') return null;
+  const visualViewportHeight = window.visualViewport?.height;
+  if (typeof visualViewportHeight === 'number' && Number.isFinite(visualViewportHeight) && visualViewportHeight > 0) {
+    return visualViewportHeight;
+  }
+  return window.innerHeight;
+}
+
+function useViewportHeightPx(enabled: boolean) {
+  const [heightPx, setHeightPx] = useState<number | null>(() => (enabled ? getViewportHeightPx() : null));
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    const updateHeight = () => setHeightPx(getViewportHeightPx());
+    updateHeight();
+
+    window.addEventListener('resize', updateHeight);
+    window.visualViewport?.addEventListener('resize', updateHeight);
+    window.visualViewport?.addEventListener('scroll', updateHeight);
+
+    return () => {
+      window.removeEventListener('resize', updateHeight);
+      window.visualViewport?.removeEventListener('resize', updateHeight);
+      window.visualViewport?.removeEventListener('scroll', updateHeight);
+    };
+  }, [enabled]);
+
+  return heightPx;
+}
+
 const SUNNY_CLOUDS: CloudSpec[] = [
   { top: '3%', left: '6%', width: '22%', height: '10%', opacity: 0.74, duration: '13s', delay: '-0.8s', filter: 'saturate(1.04) brightness(1.04)' },
   { top: '8%', left: '35%', width: '20%', height: '10%', opacity: 0.68, duration: '16s', delay: '-2.4s', filter: 'saturate(1.02) brightness(1.02)' },
@@ -344,11 +382,11 @@ function FarmHudV2({
   return (
     <div className="pointer-events-none absolute inset-x-0 top-0 z-40">
       <div
-        className={`mx-auto w-full px-2 ${useTightMobileSpacing ? 'pt-1.5 sm:pt-2' : 'pt-1 sm:pt-2'} sm:px-4`}
+        className={`mx-auto w-full px-2 ${useTightMobileSpacing ? 'pt-1 sm:pt-2' : 'pt-1 sm:pt-2'} sm:px-4`}
         style={{ maxWidth: compactMode ? '100%' : '940px' }}
       >
         <div
-          className={`flex w-full items-center justify-center px-2 ${useTightMobileSpacing ? 'h-9 gap-1 sm:h-10 sm:gap-1.5 sm:px-3' : 'h-10 gap-1.5 sm:h-11 sm:gap-2 sm:px-4'}`}
+          className={`flex w-full items-center justify-center px-2 ${useTightMobileSpacing ? 'h-8 gap-1 sm:h-10 sm:gap-1.5 sm:px-3' : 'h-10 gap-1.5 sm:h-11 sm:gap-2 sm:px-4'}`}
           style={{
             borderBottom: '1px solid rgba(100,145,175,0.22)',
             background: 'linear-gradient(180deg, rgba(167,217,242,0.42) 0%, rgba(167,217,242,0.08) 100%)',
@@ -357,7 +395,7 @@ function FarmHudV2({
           {badgeItems.map((badge) => (
             <div
               key={`farm-v2-hud-${badge.label}`}
-              className={`flex items-center rounded-full border font-semibold ${useTightMobileSpacing ? 'gap-0.5 px-1.5 py-[2px] text-[10px] sm:gap-1 sm:px-2.5 sm:text-[11px]' : 'gap-1 px-2 py-[3px] text-[11px] sm:px-3 sm:text-xs'}`}
+              className={`flex items-center rounded-full border font-semibold ${useTightMobileSpacing ? 'gap-0.5 px-1.5 py-[1px] text-[10px] sm:gap-1 sm:px-2.5 sm:text-[11px]' : 'gap-1 px-2 py-[3px] text-[11px] sm:px-3 sm:text-xs'}`}
               style={{
                 borderColor: '#b57d4a',
                 color: '#5d3a1f',
@@ -371,10 +409,10 @@ function FarmHudV2({
           ))}
         </div>
 
-        <div className={`flex justify-center ${useTightMobileSpacing ? 'mt-2' : 'mt-1.5'}`}>
+        <div className={`flex justify-center ${useTightMobileSpacing ? 'mt-1' : 'mt-1.5'}`}>
           <div
             data-testid="farm-v2-weather-badge"
-            className={`flex items-center whitespace-nowrap rounded-full border font-semibold ${useTightMobileSpacing ? 'gap-1 px-3 py-1 text-[11px] sm:gap-1.5 sm:px-3.5 sm:text-[11px]' : 'gap-1.5 px-3 py-1 text-[11px] sm:gap-2 sm:px-3.5 sm:text-xs'}`}
+            className={`flex items-center whitespace-nowrap rounded-full border font-semibold ${useTightMobileSpacing ? 'gap-1 px-2.5 py-[3px] text-[10px] sm:gap-1.5 sm:px-3.5 sm:text-[11px]' : 'gap-1.5 px-3 py-1 text-[11px] sm:gap-2 sm:px-3.5 sm:text-xs'}`}
             style={{
               borderColor: 'rgba(91, 146, 128, 0.32)',
               color: '#21503b',
@@ -685,29 +723,31 @@ function FarmBackdropV2({
   const useTightBackdrop = isNarrowScreen && !compactMode;
   const visuals = getWeatherBackdropVisuals(weather);
   const isNight = visuals.celestialKind === 'moon';
+  const tightBackdropMetrics = useTightBackdrop
+    ? {
+      skyHeight: '18.8%',
+      hillTop: '18.8%',
+      hillHeight: '12.8%',
+      backHillTop: '20.5%',
+      backHillHeight: '13.9%',
+      frontHillTop: '22.9%',
+      frontHillHeight: '10.6%',
+      grassTop: '31.9%',
+      pathTop: '28.1%',
+      leftTreeTop: '28%',
+      cottageTop: '28.6%',
+      rightTreeTop: '28.1%',
+      fenceTop: '34.2%',
+      foregroundTop: '40.8%',
+    }
+    : null;
   const skyHeight = compactMode
     ? useCompactMobilePolish
       ? '23.8%'
       : '28%'
     : useTightBackdrop
-      ? 'clamp(170px, 21.2vh, 184px)'
+      ? (tightBackdropMetrics?.skyHeight ?? '18.8%')
       : '27%';
-  // Keep the mobile horizon stable while the extra viewport height becomes usable foreground.
-  const tightBackdropMetrics = useTightBackdrop
-    ? {
-      hillTop: 'clamp(170px, 21.2vh, 184px)',
-      hillHeight: 'clamp(90px, 11vh, 98px)',
-      backHillTop: 'clamp(184px, 22.4vh, 194px)',
-      frontHillTop: 'clamp(198px, 24.1vh, 208px)',
-      grassTop: 'clamp(268px, 32.9vh, 282px)',
-      pathTop: 'clamp(194px, 23.7vh, 204px)',
-      leftTreeTop: 'clamp(194px, 23.6vh, 204px)',
-      cottageTop: 'clamp(198px, 24.2vh, 208px)',
-      rightTreeTop: 'clamp(194px, 23.7vh, 204px)',
-      fenceTop: 'clamp(232px, 28.6vh, 244px)',
-      foregroundTop: 'clamp(320px, 39vh, 334px)',
-    }
-    : null;
 
   return (
     <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden">
@@ -763,7 +803,7 @@ function FarmBackdropV2({
           height: compactMode
             ? '17.6%'
             : useTightBackdrop
-              ? 'clamp(92px, 11.6vh, 102px)'
+              ? (tightBackdropMetrics?.backHillHeight ?? '13.9%')
               : '17.2%',
           borderRadius: '50% 50% 0 0 / 78% 78% 0 0',
           background: visuals.backHillGradient,
@@ -784,7 +824,7 @@ function FarmBackdropV2({
           height: compactMode
             ? '13.6%'
             : useTightBackdrop
-              ? 'clamp(72px, 9.2vh, 82px)'
+              ? (tightBackdropMetrics?.frontHillHeight ?? '10.6%')
               : '13.2%',
           borderRadius: '54% 46% 0 0 / 100% 100% 0 0',
           background: visuals.frontHillGradient,
@@ -984,7 +1024,7 @@ function FarmBackdropV2({
           height: compactMode
             ? '44%'
             : useTightBackdrop
-              ? 'calc(100% - clamp(338px, 41.5vh, 352px))'
+              ? `calc(100% - ${tightBackdropMetrics?.foregroundTop ?? '40.8%'})`
               : '46%',
           background: visuals.foregroundGradient,
         }}
@@ -1091,37 +1131,48 @@ export function FarmPlotBoardV2({
   const isNarrowScreen = typeof window !== 'undefined' && window.innerWidth < 640;
   const useCompactMobilePolish = compactMode && isNarrowScreen;
   const useTightMobileSpacing = isNarrowScreen && !compactMode;
+  const viewportHeightPx = useViewportHeightPx(useTightMobileSpacing || useCompactMobilePolish);
+  const tightSceneHeightPx = useMemo(
+    () => (useTightMobileSpacing ? clampNumber(Math.round((viewportHeightPx ?? 800) * 0.76), 600, 644) : null),
+    [useTightMobileSpacing, viewportHeightPx],
+  );
+  const tightBoardPaddingTopPx = useMemo(
+    () => (tightSceneHeightPx ? clampNumber(Math.round(tightSceneHeightPx * 0.35), 214, 232) : null),
+    [tightSceneHeightPx],
+  );
 
   const boardWidth = compactMode
     ? 'min(96vw, 500px)'
     : useTightMobileSpacing
-      ? 'min(calc(100% - 26px), 470px)'
+      ? 'min(calc(100% - 24px), 470px)'
       : 'min(82vw, calc(100dvh - 290px), 620px)';
-  const boardGap = compactMode || useTightMobileSpacing
+  const boardGap = compactMode
     ? 'clamp(6px, 1vw, 9px)'
-    : 'clamp(8px, 0.8vw, 11px)';
+    : useTightMobileSpacing
+      ? 'clamp(5px, 0.9vw, 8px)'
+      : 'clamp(8px, 0.8vw, 11px)';
   const sceneMinHeight = compactMode
     ? useCompactMobilePolish
       ? '100dvh'
       : 'min(100dvh, 630px)'
     : useTightMobileSpacing
-      ? 'clamp(618px, calc(100dvh - 118px - env(safe-area-inset-bottom, 0px)), 724px)'
+      ? `${tightSceneHeightPx ?? 620}px`
       : 'min(76dvh, 660px)';
   const boardPaddingTop = compactMode
     ? useCompactMobilePolish
       ? 'clamp(162px, 29vh, 204px)'
       : 'clamp(168px, 31vh, 214px)'
     : useTightMobileSpacing
-      ? 'clamp(274px, 34vh, 296px)'
+      ? `${tightBoardPaddingTopPx ?? 222}px`
       : 'clamp(96px, 14.5vh, 132px)';
   const boardPaddingBottom = compactMode
     ? useCompactMobilePolish
       ? 'clamp(4px, 0.8vh, 8px)'
       : 'clamp(6px, 1.1vh, 10px)'
     : useTightMobileSpacing
-      ? 'calc(env(safe-area-inset-bottom, 0px) + clamp(10px, 1.6vh, 16px))'
+      ? 'calc(env(safe-area-inset-bottom, 0px) + 8px)'
       : 'clamp(18px, 2.5vh, 28px)';
-  const hudWeatherBadgeOffset = useTightMobileSpacing ? 38 : compactMode ? 38 : 34;
+  const hudWeatherBadgeOffset = useTightMobileSpacing ? 28 : compactMode ? 38 : 34;
   const backdropVisuals = getWeatherBackdropVisuals(weather);
 
   useEffect(() => {
@@ -1237,7 +1288,7 @@ export function FarmPlotBoardV2({
                   key={`farm-v2-slot-${plot?.id ?? index}`}
                   data-slot-state={tileState}
                   style={{
-                    transform: `translateY(${Math.floor(index / GRID_SIDE) * (compactMode ? 2.4 : 3.2)}px)`,
+                    transform: `translateY(${Math.floor(index / GRID_SIDE) * (compactMode ? 2.4 : useTightMobileSpacing ? 2.2 : 3.2)}px)`,
                   }}
                 >
                   <FarmPlotTileV2

--- a/src/components/farm-v2/FarmPlotBoardV2.tsx
+++ b/src/components/farm-v2/FarmPlotBoardV2.tsx
@@ -734,10 +734,10 @@ function FarmBackdropV2({
       frontHillHeight: '10.6%',
       grassTop: '31.9%',
       pathTop: '28.1%',
-      leftTreeTop: '28%',
-      cottageTop: '28.6%',
-      rightTreeTop: '28.1%',
-      fenceTop: '34.2%',
+      leftTreeTop: '28.5%',
+      cottageTop: '29.2%',
+      rightTreeTop: '28.6%',
+      fenceTop: '35.1%',
       foregroundTop: '40.8%',
     }
     : null;


### PR DESCRIPTION
## Summary
- trim narrow mobile farm shell padding and toolbar spacing so the plot scene starts earlier
- lower the tight-mobile fence/tree/cottage stack to better match the board after the viewport rebalance
- make the Playwright proof seed deterministic by disabling random alien visit overlays

## Validation
- npm run lint
- npm run build
- BASE_URL=http://127.0.0.1:4275 node artifacts/issue-134/proof-capture-address-bar.mjs artifacts/issue-134/proof-reject-fix-final

## Context
Follow-up for issue #134 after real Android feedback on the merged narrow-screen pass.