### PR TITLE
fix: follow up tight mobile farm scene spacing

### DIFF
--- a/artifacts/issue-134/proof-capture-address-bar.mjs
+++ b/artifacts/issue-134/proof-capture-address-bar.mjs
@@ -103,6 +103,10 @@ function createSeedState() {
       current: 'sunny',
       lastChangeAt: now,
     },
+    alienVisit: {
+      lastMelonAlienCheckDate: getTodayKey(now),
+      current: null,
+    },
   };
 }
 
@@ -116,6 +120,7 @@ async function seedInit(page) {
     localStorage.setItem('watermelon-shed', JSON.stringify(payload.shed));
     localStorage.setItem('watermelon-genes', JSON.stringify(payload.gene));
     localStorage.setItem('weatherState', JSON.stringify(payload.weatherState));
+    localStorage.setItem('alienVisit', JSON.stringify(payload.alienVisit));
     localStorage.removeItem('weatherDebugOverride');
     localStorage.removeItem('watermelon-debug');
   }, state);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pomodoro",
-  "version": "0.61.21",
+  "version": "0.61.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pomodoro",
-      "version": "0.61.21",
+      "version": "0.61.22",
       "dependencies": {
         "@capacitor/android": "^8.1.0",
         "@capacitor/cli": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pomodoro",
   "private": true,
-  "version": "0.61.21",
+  "version": "0.61.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/FarmPage.tsx
+++ b/src/components/FarmPage.tsx
@@ -459,7 +459,7 @@ export function FarmPage({
 
   return (
     <div
-      className={`flex-1 flex flex-col w-full ${compactShell ? 'px-0 pt-0 pb-0 gap-0' : useTightMobileFarmShell ? 'px-2.5 sm:px-4 pt-1 pb-2 gap-1.5' : gentleV2Layout ? 'px-3 sm:px-4 pt-2 pb-3 gap-2' : 'px-4 pt-4 pb-6 gap-4'}`}
+      className={`flex-1 flex flex-col w-full ${compactShell ? 'px-0 pt-0 pb-0 gap-0' : useTightMobileFarmShell ? 'px-2 sm:px-4 pt-0.5 pb-1.5 gap-1' : gentleV2Layout ? 'px-3 sm:px-4 pt-2 pb-3 gap-2' : 'px-4 pt-4 pb-6 gap-4'}`}
       style={gentleV2Layout
         ? {
           background: 'linear-gradient(180deg, #9ad7f4 0%, #a6def2 28%, #a8d993 56%, #94cf73 100%)',
@@ -472,7 +472,7 @@ export function FarmPage({
           <SubTabHeader subTab={subTab} setSubTab={setSubTab} theme={theme} t={t} gentle={useFarmPlotBoardV2} />
 
           {/* 道具快捷栏 */}
-          <div className={`flex items-center overflow-x-auto no-scrollbar ${useTightMobileFarmShell ? 'gap-1.5 pb-0.5' : 'gap-2 pb-1'}`}>
+          <div className={`flex items-center overflow-x-auto no-scrollbar ${useTightMobileFarmShell ? 'gap-1 pb-0' : 'gap-2 pb-1'}`}>
             {(lullabyCount > 0 || lullabyActive) && (
               <button
                 type="button"
@@ -657,7 +657,7 @@ export function FarmPage({
 
       {/* 农场场景 */}
       <div
-        className={`farm-page relative isolate min-h-0 ${useFarmPlotBoardV2 && !compactShell ? 'flex-none -mx-2.5 sm:mx-0 sm:flex-1' : 'flex-1'} ${compactShell ? 'pt-0' : useTightMobileFarmShell ? 'pt-0.5' : gentleV2Layout ? 'pt-1' : 'pt-4'}`}
+        className={`farm-page relative isolate min-h-0 ${useFarmPlotBoardV2 && !compactShell ? 'flex-none -mx-2 sm:mx-0 sm:flex-1' : 'flex-1'} ${compactShell ? 'pt-0' : useTightMobileFarmShell ? 'pt-0' : gentleV2Layout ? 'pt-1' : 'pt-4'}`}
         style={compactShell
           ? {
             background: 'linear-gradient(180deg, #90d6f6 0%, #bdeafd 38%, #b4e8a6 58%, #9ad577 80%, #8cc764 100%)',

--- a/src/components/farm-v2/FarmPlotBoardV2.tsx
+++ b/src/components/farm-v2/FarmPlotBoardV2.tsx
@@ -734,10 +734,10 @@ function FarmBackdropV2({
       frontHillHeight: '10.6%',
       grassTop: '31.9%',
       pathTop: '28.1%',
-      leftTreeTop: '28%',
-      cottageTop: '28.6%',
-      rightTreeTop: '28.1%',
-      fenceTop: '34.2%',
+      leftTreeTop: '28.5%',
+      cottageTop: '29.2%',
+      rightTreeTop: '28.6%',
+      fenceTop: '35.1%',
       foregroundTop: '40.8%',
     }
     : null;


### PR DESCRIPTION
## Summary
- trim narrow mobile farm shell padding and toolbar spacing so the plot scene starts earlier
- lower the tight-mobile fence/tree/cottage stack to better match the board after the viewport rebalance
- make the Playwright proof seed deterministic by disabling random alien visit overlays

## Validation
- npm run lint
- npm run build
- BASE_URL=http://127.0.0.1:4275 node artifacts/issue-134/proof-capture-address-bar.mjs artifacts/issue-134/proof-reject-fix-final

## Context
Follow-up for issue #134, rebuilt from current main so the PR only carries this repair delta.